### PR TITLE
fix: report version at startup W-18740902

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@jsforce/jsforce-node": "^3.8.2",
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@oclif/core": "^4.3.1",
+    "@oclif/core": "^4.3.3",
     "@salesforce/core": "^8.11.4",
     "@salesforce/kit": "^3.1.6",
     "@salesforce/source-deploy-retrieve": "^12.19.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ You can also use special values to control access to orgs:
       delimiter: ',',
       default: ['all'],
     })(),
+    version: Flags.version(),
   };
 
   public static examples = [
@@ -98,7 +99,7 @@ You can also use special values to control access to orgs:
     this.logToStderr(`Allowed orgs:\n${flags.orgs.map((org) => `- ${org}`).join('\n')}`);
     const server = new McpServer({
       name: 'sf-mcp-server',
-      version: '0.0.6',
+      version: this.config.version,
       capabilities: {
         resources: {},
         tools: {},
@@ -153,6 +154,6 @@ You can also use special values to control access to orgs:
 
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error('✅ Salesforce MCP Server running on stdio');
+    console.error(`✅ Salesforce MCP Server v${this.config.version} running on stdio`);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,10 +1441,10 @@
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/core@^4.3.1":
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/@oclif/core/-/core-4.3.1.tgz"
-  integrity sha512-+QpJSficjZWu65YSRJIwe50xh0C7WVD6BkQyk0HmGIlx2/rvex8LDwbZHCQcvuJDOCVQeX/INh8IImuKn4d1UA==
+"@oclif/core@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-4.3.3.tgz#a527536b62ef202c58d2b69ce9cd1e64eb3a94b1"
+  integrity sha512-A0mk4nlVE+r34fl91OdglXVPwhhfzM59IhSxnOigqMkwxFgT8z3i2WlUgzmazzvzSccs2KM4N2HkTS3NEvW96g==
   dependencies:
     ansi-escapes "^4.3.2"
     ansis "^3.17.0"
@@ -1460,7 +1460,7 @@
     semver "^7.6.3"
     string-width "^4.2.3"
     supports-color "^8"
-    tinyglobby "^0.2.13"
+    tinyglobby "^0.2.14"
     widest-line "^3.1.0"
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
@@ -8445,7 +8445,7 @@ tiny-jsonc@^1.0.2:
   resolved "https://registry.npmjs.org/tiny-jsonc/-/tiny-jsonc-1.0.2.tgz"
   integrity sha512-f5QDAfLq6zIVSyCZQZhhyl0QS6MvAyTxgz4X4x3+EoCktNWEYJ6PeoEA97fyb98njpBNNi88ybpD7m+BDFXaCw==
 
-tinyglobby@^0.2.13, tinyglobby@^0.2.9:
+tinyglobby@^0.2.13, tinyglobby@^0.2.14, tinyglobby@^0.2.9:
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.14.tgz#5280b0cf3f972b050e74ae88406c0a6a58f4079d"
   integrity sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==


### PR DESCRIPTION
### What does this PR do?
* Adds `--version` flag
* Prints server version at startup

Bumped oclif/core to get this fix for the version flag:
https://github.com/oclif/core/blob/main/CHANGELOG.md#bug-fixes-1

<img width="865" alt="Screenshot 2025-06-09 at 18 30 31" src="https://github.com/user-attachments/assets/87f67cbb-882d-4c7f-ab34-3f5ad2312192" />


### What issues does this PR fix or reference?
@W-18740902@