### PR TITLE
fix: don't finish process if no org is found

### DIFF
--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -128,12 +128,6 @@ export async function getAllAllowedOrgs(): Promise<SanitizedOrgAuthorization[]> 
   // Filter out orgs that are not in ORG_ALLOWLIST
   const allowedOrgs = await filterAllowedOrgs(sanitizedOrgs, orgAllowList);
 
-  // If no orgs are found, stop the server
-  if (allowedOrgs.length === 0) {
-    console.error('No orgs found that match the allowed orgs configuration. Check MCP Server startup config.');
-    process.exit(1);
-  }
-
   return allowedOrgs;
 }
 


### PR DESCRIPTION
### What does this PR do?
Removes the check that was finishing the process when no orgs where found in the allowlist.

Repro:
either `--orgs DEFAULT_TARGET_ORG` or any combination that would result in no orgs found by the server.

Before:
server exits via `process.exit(1)` and host gets `Canceled: Canceled` as the tool output
![Screenshot 2025-06-24 at 17 09 07](https://github.com/user-attachments/assets/78a9641b-542a-4bf5-8d53-ff36c36b5691)

After:
server continues running, tools return proper msg suggesting the user valid actions to take:
![Screenshot 2025-06-24 at 17 11 26](https://github.com/user-attachments/assets/74b058fe-6b2e-45b0-bb0a-ca2cdf0b586e)

### What issues does this PR fix or reference?
