### PR TITLE
The mcp.json for Cursor is formatted incorrectly: "command" needs to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,8 @@ To configure [Cursor](https://www.cursor.com/) to work with Salesforce DX MCP Se
 {
   "mcpServers": {
     "salesforce": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@salesforce/mcp", "--orgs", "DEFAULT_TARGET_ORG", "--toolsets", "all"]
-      }
+      "command": "npx",
+      "args": ["-y", "@salesforce/mcp", "--orgs", "DEFAULT_TARGET_ORG", "--toolsets", "all"]
     }
   }
 }


### PR DESCRIPTION
…be a string instead of an object.

### What does this PR do?

Fixes the README to use the correct mcp.json format for Cursor

### What issues does this PR fix or reference?
