### PR TITLE
feat: sf-org-open W-18944112

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@salesforce/source-tracking": "^7.4.6",
     "@salesforce/telemetry": "^6.0.39",
     "@salesforce/ts-types": "^2.0.11",
+    "open": "^10.1.2",
     "zod": "^3.25.67"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,7 @@ You can also use special values to control access to orgs:
       this.logToStderr('Registering org tools');
       // list all orgs
       orgs.registerToolListAllOrgs(server);
+      orgs.registerToolOrgOpen(server);
     }
 
     // ************************

--- a/src/tools/orgs/index.ts
+++ b/src/tools/orgs/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './sf-list-all-orgs.js';
+export * from './sf-org-open.js';

--- a/src/tools/orgs/sf-org-open.ts
+++ b/src/tools/orgs/sf-org-open.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'zod';
+import { Org } from '@salesforce/core';
+import { MetadataResolver } from '@salesforce/source-deploy-retrieve';
+import open from 'open';
+import { textResponse } from '../../shared/utils.js';
+import { directoryParam, usernameOrAliasParam } from '../../shared/params.js';
+import { SfMcpServer } from '../../sf-mcp-server.js';
+
+export const orgOpenParamsSchema = z.object({
+  filePath: z.string().optional().describe('File path of the metadata to open in the org.'),
+  usernameOrAlias: usernameOrAliasParam,
+  directory: directoryParam,
+});
+
+export type OrgOpenParamsSchema = z.infer<typeof orgOpenParamsSchema>;
+
+export const registerToolOrgOpen = (server: SfMcpServer): void => {
+  server.tool(
+    'sf-org-open',
+    `Open a Salesforce org in the browser.
+
+You can specify a metadata file you want to open.
+`,
+    orgOpenParamsSchema.shape,
+    {
+      title: 'Open org in browser',
+      // TODO: switch to true for prod
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    async ({ usernameOrAlias, filePath: metadataFilePath, directory }) => {
+      process.chdir(directory);
+
+      const org = await Org.create({
+        aliasOrUsername: usernameOrAlias,
+      });
+
+      if (metadataFilePath) {
+        const metadataResolver = new MetadataResolver();
+        const components = metadataResolver.getComponentsFromPath(metadataFilePath);
+        const typeName = components[0]?.type?.name;
+
+        const metadataBuilderUrl = await org.getMetadataBuilderUrl(typeName, metadataFilePath);
+        await open(metadataBuilderUrl);
+
+        return textResponse(
+          `Successfully opened the org in your browser. ${
+            metadataBuilderUrl.includes('FlexiPageList')
+              ? "This metadata file doesn't have a builder UI, opened Lightning App Builder instead."
+              : ''
+          }`
+        );
+      }
+
+      await open(await org.getFrontDoorUrl());
+
+      return textResponse('Successfully opened the org in your browser.');
+    }
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4998,18 +4998,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.11, fast-glob@^3.2.9:
-  version "3.3.2"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz"
-  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
-fast-glob@^3.3.2:
+fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
@@ -6199,16 +6188,7 @@ istanbul-lib-processinfo@^2.0.2:
     rimraf "^3.0.0"
     uuid "^3.3.3"
 
-istanbul-lib-report@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz"
-  integrity sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==
-  dependencies:
-    istanbul-lib-coverage "^3.0.0"
-    make-dir "^3.0.0"
-    supports-color "^7.1.0"
-
-istanbul-lib-report@^3.0.1:
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
   integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
@@ -6226,15 +6206,7 @@ istanbul-lib-source-maps@^4.0.0:
     istanbul-lib-coverage "^3.0.0"
     source-map "^0.6.1"
 
-istanbul-reports@^3.0.2:
-  version "3.1.4"
-  resolved "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz"
-  integrity sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==
-  dependencies:
-    html-escaper "^2.0.0"
-    istanbul-lib-report "^3.0.0"
-
-istanbul-reports@^3.1.7:
+istanbul-reports@^3.0.2, istanbul-reports@^3.1.7:
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.7.tgz#daed12b9e1dca518e15c056e1e537e741280fa0b"
   integrity sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==
@@ -6843,7 +6815,7 @@ micromark-util-types@^2.0.0:
   resolved "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz"
   integrity sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==
 
-micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.8:
+micromatch@^4.0.2, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -7314,6 +7286,16 @@ oniguruma-to-es@^2.2.0:
 open@^10.1.0:
   version "10.1.2"
   resolved "https://registry.npmjs.org/open/-/open-10.1.2.tgz"
+  integrity sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==
+  dependencies:
+    default-browser "^5.2.1"
+    define-lazy-prop "^3.0.0"
+    is-inside-container "^1.0.0"
+    is-wsl "^3.1.0"
+
+open@^10.1.2:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-10.1.2.tgz#d5df40984755c9a9c3c93df8156a12467e882925"
   integrity sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==
   dependencies:
     default-browser "^5.2.1"


### PR DESCRIPTION
### What does this PR do?
DEPENDS ON: https://github.com/forcedotcom/sfdx-core/pull/1209

Adds an MCP tool to open the org in the browser, also supports opening certain metadata files in their builder UI.

TODO:
- [ ] see what other setup sections could be handy to support opening, think:
```
what's up with this bulk job failure, let's open the ui for more details
open this deploy 
open the sandboxes panel
```
- [] ensure the tool doesn't expose the URL, just open it in the browser

### What issues does this PR fix or reference?
@W-18944112@