### PR TITLE
fix: add shrinkwrap lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/mcp",
-  "version": "0.17.0",
+  "version": "0.17.1-dev.0",
   "description": "MCP Server for interacting with Salesforce instances",
   "bin": {
     "sf-mcp-server": "bin/run.js"


### PR DESCRIPTION
### What does this PR do?

Adds a shrinkwrap lockfile to lock deps at publish time and speed up brand new installs.
I noticed it yesterday on a clean machine when installing via `npm -g ...` that it was taking a few seconds resolving all deps.

### What issues does this PR fix or reference?
