### PR TITLE
chore: bump provider-api module @W-19407110@

### DIFF
--- a/packages/EXAMPLE-MCP-PROVIDER/package.json
+++ b/packages/EXAMPLE-MCP-PROVIDER/package.json
@@ -14,7 +14,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.3",
-    "@salesforce/mcp-provider-api": "^0.1.0",
+    "@salesforce/mcp-provider-api": "^0.2.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/mcp-provider-code-analyzer/package.json
+++ b/packages/mcp-provider-code-analyzer/package.json
@@ -20,7 +20,7 @@
         "@salesforce/code-analyzer-pmd-engine": "0.28.0",
         "@salesforce/code-analyzer-regex-engine": "0.24.0",
         "@salesforce/code-analyzer-retirejs-engine": "0.24.0",
-        "@salesforce/mcp-provider-api": "0.1.0",
+        "@salesforce/mcp-provider-api": "0.2.0",
         "zod": "^3.23.8"
     },
     "devDependencies": {

--- a/packages/mcp-provider-dx-core/package.json
+++ b/packages/mcp-provider-dx-core/package.json
@@ -48,7 +48,7 @@
     "@salesforce/apex-node": "^8.2.1",
     "@salesforce/core": "^8.18.0",
     "@salesforce/kit": "^3.1.6",
-    "@salesforce/mcp-provider-api": "^0.1.0",
+    "@salesforce/mcp-provider-api": "^0.2.0",
     "@salesforce/source-deploy-retrieve": "^12.22.0",
     "@salesforce/source-tracking": "^7.4.8",
     "@salesforce/ts-types": "^2.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3093,17 +3093,6 @@
   dependencies:
     "@salesforce/ts-types" "^2.0.12"
 
-"@salesforce/mcp-provider-api@0.1.0", "@salesforce/mcp-provider-api@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/mcp-provider-api/-/mcp-provider-api-0.1.0.tgz#2f1bb20d66fc7213156f7464f9a332055588e757"
-  integrity sha512-bdNcDW7pkFWOLN+fE3I0FwfeBhglnNU+fW/dB2X+/LX9Pq2xXx2VbN89UlvvFJ7sbvoFK1wVDgaroWChP5rK+Q==
-  dependencies:
-    "@modelcontextprotocol/sdk" "^1.17.3"
-    "@salesforce/core" "^8"
-    "@salesforce/ts-types" "^2"
-    semver "^7.7.2"
-    zod "^3.23.8"
-
 "@salesforce/o11y-reporter@1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@salesforce/o11y-reporter/-/o11y-reporter-1.3.2.tgz#36e30312135dc3e5842358a5bdd0ae8f796cfcf0"


### PR DESCRIPTION
### What does this PR do?
After https://github.com/salesforcecli/mcp/pull/163 and the workflows PR got both merged into `main` I triggered a manual release for the provider-api:
https://github.com/salesforcecli/mcp/actions/runs/17305684046

Something I missed in my PR is that when releasing the `mcp-provider-api` pkg we should also bump it in all providers instead of just the main MCP module, so that whenever a change happens there you just do:
1. `mcp-provider-api` release
2. matrix release of all providers in parallel
3. server release



### What issues does this PR fix or reference?
@W-19407110@