### PR TITLE
fix(W-19431143): Renaming sfca tools to match style guide

### DIFF
--- a/packages/mcp-provider-code-analyzer/src/tools/sf-code-analyzer-describe-rule.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/sf-code-analyzer-describe-rule.ts
@@ -5,31 +5,15 @@ import { DescribeRuleAction, DescribeRuleActionImpl, DescribeRuleInput, Describe
 import { CodeAnalyzerConfigFactoryImpl } from "../factories/CodeAnalyzerConfigFactory.js";
 import { EnginePluginsFactoryImpl } from "../factories/EnginePluginsFactory.js";
 import { getErrorMessage } from "../utils.js";
+import {CodeAnalyzerRunMcpTool} from "./sf-code-analyzer-run.js";
 
 const DESCRIPTION: string = `A tool for getting the description of a Code Analyzer rule.\n` +
     `This tool can return a JSON that describes the properties of a Code Analyzer rule, which may include information about\n` +
     `how it can be fixed.\n` +
     `\n` +
     `When to use this tool:\n` +
-    `- When analysis results reference a rule but do not provide enough information for you to confidently fix the violation.\n` +
-    `- When the user asks for information about a specific rule or violation.\n` +
-    `\n` +
-    `Parameters explained:\n` +
-    `- ruleName: A string corresponding to the name of the rule that should be described.\n` +
-    `- engineName: A string corresponding to the name of the engine to which the desired rule belongs.\n` +
-    `\n` +
-    `Output explained:\n` +
-    `- status: A string indicating whether the operation as a whole was successful.\n` +
-    `  * In a successful run, this will be "success".\n` +
-    `  * In a failed run, this will be an error message.\n` +
-    `- rule: A JSON containing the properties of the rule. If this property is absent, it means no such rule existed.\n` +
-    `  The JSON will have the following properties:\n` +
-    `  - name: The name of the rule. Will be equal to the "ruleName" supplied as input to the tool.\n` +
-    `  - engine: The name of the engine to which this rule belongs. Equivalent to the "engineName" input.\n` +
-    `  - severity: A number between 1 and 5 indicating the severity of the rule. Lower numbers are MORE severe.\n` +
-    `  - tags: An array of strings indicating the tags that are applicable to this rule, e.g. "performance", "security", etc.\n` +
-    `  - description: A string describing the purpose and functionality of the rule in question.\n` +
-    `  - resources: A possibly-empty array of strings indicating URLs or paths to documentation or other helpful information.\n`;
+    `- When the results file from the ${CodeAnalyzerRunMcpTool.NAME} tool does not provide enough information to fix a violation yourself.\n` +
+    `- When the user asks for information about a specific rule or violation.`;
 
 const inputSchema = z.object({
     ruleName: z.string().describe('The name of a rule about which more information is required'),
@@ -52,6 +36,7 @@ type OutputArgsShape = typeof outputSchema.shape;
 
 
 export class CodeAnalyzerDescribeRuleMcpTool extends McpTool<InputArgsShape, OutputArgsShape> {
+    public static readonly NAME: string = 'describe_code_analyzer_rule';
     private readonly action: DescribeRuleAction;
 
     public constructor(
@@ -73,7 +58,7 @@ export class CodeAnalyzerDescribeRuleMcpTool extends McpTool<InputArgsShape, Out
     }
 
     public getName(): string {
-        return "describe_code_analyzer_rule";
+        return CodeAnalyzerDescribeRuleMcpTool.NAME;
     }
 
     public getConfig(): McpToolConfig<InputArgsShape, OutputArgsShape> {

--- a/packages/mcp-provider-code-analyzer/src/tools/sf-code-analyzer-describe-rule.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/sf-code-analyzer-describe-rule.ts
@@ -73,7 +73,7 @@ export class CodeAnalyzerDescribeRuleMcpTool extends McpTool<InputArgsShape, Out
     }
 
     public getName(): string {
-        return "sf-code-analyzer-describe-rule"; 
+        return "describe_code_analyzer_rule";
     }
 
     public getConfig(): McpToolConfig<InputArgsShape, OutputArgsShape> {

--- a/packages/mcp-provider-code-analyzer/src/tools/sf-code-analyzer-run.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/sf-code-analyzer-run.ts
@@ -17,23 +17,7 @@ const DESCRIPTION: string = `A tool for performing static analysis against code.
     `\n` +
     `When to use this tool:\n` +
     `- When the user asks you to generate files, use this tool to scan those files.\n` +
-    `- When the user asks you to check code for problems, use this tool to do that.\n` +
-    `\n` +
-    `Parameters explained:\n` +
-    `- target: An Array of absolute paths to files that should be scanned.\n` +
-    `  * This list MUST include files, and CANNOT include directories or globs.\n` +
-    `  * ALL files included in this array must actually exist on the user's machine.\n` +
-    `  * The array MUST be non-empty.\n` +
-    `  * The array can contain a MAXIMUM of ${MAX_ALLOWABLE_TARGET_COUNT} entries. If there are more than ten files to scan, the tool should be called multiple times.\n` +
-    `\n` +
-    `Output explained:\n` +
-    `- status: A string indicating whether the operation as a whole was successful.\n` +
-    `  * In a successful run, this will be "success".\n` +
-    `  * In a failed run, this will be an error message.\n` +
-    `- resultsFile: The absolute path to the results file. Read from this file to see what violations were found in the\n` +
-    `  target files, so that either you or the user can fix them.\n` +
-    `  * If the analysis finished successfully, this property will be present.\n` +
-    `  * If the analysis failed, then this property will be absent.\n`;
+    `- When the user asks you to check code for problems, use this tool to do that.\n`;
 
 const inputSchema = z.object({
     target: z.array(z.string()).describe(`A JSON-formatted array of between 1 and ${MAX_ALLOWABLE_TARGET_COUNT} files on the users machine that should be scanned.`)
@@ -48,6 +32,7 @@ type OutputArgsShape = typeof outputSchema.shape;
 
 
 export class CodeAnalyzerRunMcpTool extends McpTool<InputArgsShape, OutputArgsShape> {
+    public static readonly NAME: string = 'run_code_analyzer';
     private readonly action: RunAnalyzerAction;
 
     public constructor(
@@ -69,7 +54,7 @@ export class CodeAnalyzerRunMcpTool extends McpTool<InputArgsShape, OutputArgsSh
     }
 
     public getName(): string {
-        return "run_code_analysis";
+        return CodeAnalyzerRunMcpTool.NAME;
     }
 
     public getConfig(): McpToolConfig<InputArgsShape, OutputArgsShape> {

--- a/packages/mcp-provider-code-analyzer/src/tools/sf-code-analyzer-run.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/sf-code-analyzer-run.ts
@@ -69,7 +69,7 @@ export class CodeAnalyzerRunMcpTool extends McpTool<InputArgsShape, OutputArgsSh
     }
 
     public getName(): string {
-        return "sf-code-analyzer-run"; 
+        return "run_code_analysis";
     }
 
     public getConfig(): McpToolConfig<InputArgsShape, OutputArgsShape> {

--- a/packages/mcp-provider-code-analyzer/test/tools/describe-rule-tool.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/tools/describe-rule-tool.test.ts
@@ -19,7 +19,7 @@ describe("Tests for DescribeRuleTool", () => {
     });
 
     it("When getName is called, then 'sf-example' is returned", () => {
-        expect(tool.getName()).toEqual('sf-code-analyzer-describe-rule');
+        expect(tool.getName()).toEqual('describe_code_analyzer_rule');
     });
 
     it("When getConfig is called, then the correct configuration is returned", () => {

--- a/packages/mcp-provider-code-analyzer/test/tools/sf-code-analyzer-run.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/tools/sf-code-analyzer-run.test.ts
@@ -26,7 +26,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
     });
 
     it("When getName is called, then 'sf-example' is returned", () => {
-        expect(tool.getName()).toEqual('sf-code-analyzer-run');
+        expect(tool.getName()).toEqual('run_code_analyzer');
     });
 
     it("When getConfig is called, then the correct configuration is returned", () => {


### PR DESCRIPTION
### What does this PR do?

Previously, the SF Code analyzer tools' names were chosen based on our own intuition, which it turns out clashes with the style guide. So we're changing them to match the style guide.

### What issues does this PR fix or reference?
@W-19431143@