### PR TITLE
chore: add e2e tests for code-analyzer tools

### DIFF
--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -200,6 +200,7 @@ jobs:
           - 'yarn test:e2e'
         provider:
           - 'mcp-provider-dx-core'
+          - 'mcp-provider-code-analyzer'
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
           - 'yarn test:e2e'
         provider:
           - 'mcp-provider-dx-core'
+          - 'mcp-provider-code-analyzer'
       fail-fast: false
     with:
       os: ${{ matrix.os }}

--- a/packages/mcp-provider-code-analyzer/package.json
+++ b/packages/mcp-provider-code-analyzer/package.json
@@ -47,6 +47,7 @@
     "lint": "eslint **/*.ts",
     "postclean": "rimraf dist && rimraf ./*.tgz",
     "package": "yarn pack",
-    "test": "tsc --build tsconfig.json --noEmit && vitest run --coverage"
+    "test": "tsc --build tsconfig.json --noEmit && vitest run --coverage --exclude \"test/e2e/**/*.test.ts\"",
+    "test:e2e": "tsc --build tsconfig.json --noEmit && vitest run \"test/e2e\""
   }
 }

--- a/packages/mcp-provider-code-analyzer/package.json
+++ b/packages/mcp-provider-code-analyzer/package.json
@@ -20,6 +20,7 @@
     "@salesforce/code-analyzer-pmd-engine": "^0.30.0",
     "@salesforce/code-analyzer-regex-engine": "^0.27.0",
     "@salesforce/code-analyzer-retirejs-engine": "^0.26.0",
+    "@salesforce/mcp-test-client": "0.0.1",
     "@salesforce/mcp-provider-api": "^0.4.0",
     "zod": "^3.25.76"
   },

--- a/packages/mcp-provider-code-analyzer/src/tools/describe_code_analyzer_rule.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/describe_code_analyzer_rule.ts
@@ -15,7 +15,7 @@ const DESCRIPTION: string = `A tool for getting the description of a Code Analyz
     `- When the results file from the ${CodeAnalyzerRunMcpTool.NAME} tool does not provide enough information to fix a violation yourself.\n` +
     `- When the user asks for information about a specific rule or violation.`;
 
-const inputSchema = z.object({
+export const inputSchema = z.object({
     ruleName: z.string().describe('The name of a rule about which more information is required'),
     engineName: z.string().describe('The engine to which the rule belongs. Resolves ambiguity when rules have the same name.')
 });

--- a/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
@@ -19,7 +19,7 @@ const DESCRIPTION: string = `A tool for performing static analysis against code.
     `- When the user asks you to generate files, use this tool to scan those files.\n` +
     `- When the user asks you to check code for problems, use this tool to do that.\n`;
 
-const inputSchema = z.object({
+export const inputSchema = z.object({
     target: z.array(z.string()).describe(`A JSON-formatted array of between 1 and ${MAX_ALLOWABLE_TARGET_COUNT} files on the users machine that should be scanned.`)
 });
 type InputArgsShape = typeof inputSchema.shape;

--- a/packages/mcp-provider-code-analyzer/test/e2e/describe_code_analyzer_rule-e2e.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/e2e/describe_code_analyzer_rule-e2e.test.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { McpTestClient, DxMcpTransport } from '@salesforce/mcp-test-client';
+import { inputSchema } from '../../src/tools/describe_code_analyzer_rule.js';
+
+describe('describe_code_analyzer_rule', () => {
+    const client = new McpTestClient({
+        timeout: 60000
+    });
+
+    const testInputSchema = {
+        name: z.literal('describe_code_analyzer_rule'),
+        params: inputSchema
+    };
+
+    beforeAll(async () => {
+        try {
+            const transport = DxMcpTransport({
+                args: ['--toolsets', 'all', '--orgs', 'DEFAULT_TARGET_ORG', '--no-telemetry', '--allow-non-ga-tools']
+            });
+            await client.connect(transport);
+        } catch (error) {
+            console.error('Setup failed:', error);
+            throw error;
+        }
+    });
+
+    afterAll(async () => {
+        if (client?.connected) {
+            await client.disconnect();
+        }
+    });
+
+    it('should offer rule description for existing rule', async () => {
+        const result = await client.callTool(testInputSchema, {
+            name: 'describe_code_analyzer_rule',
+            params: {
+                ruleName: 'VfUnescapeEl',
+                engineName: 'pmd'
+            }
+        });
+
+        expect(result.structuredContent!.status).toEqual('success');
+        expect(result.structuredContent!.rule).toHaveProperty('name', 'VfUnescapeEl');
+        expect(result.structuredContent!.rule).toHaveProperty('engine', 'pmd');
+        expect(result.structuredContent!.rule).toHaveProperty('severity', 2);
+    });
+
+    it('should offer error for non-existent rule', async () => {
+        const result = await client.callTool(testInputSchema, {
+            name: 'describe_code_analyzer_rule',
+            params: {
+                ruleName: 'NotARealRule',
+                engineName: 'pmd'
+            }
+        });
+
+        expect(result.structuredContent!.status).toContain(`No rule with name 'NotARealRule' exists in engine 'pmd'.`);
+    });
+})

--- a/packages/mcp-provider-code-analyzer/test/e2e/describe_code_analyzer_rule-e2e.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/e2e/describe_code_analyzer_rule-e2e.test.ts
@@ -15,7 +15,7 @@ describe('describe_code_analyzer_rule', () => {
     beforeAll(async () => {
         try {
             const transport = DxMcpTransport({
-                args: ['--toolsets', 'all', '--orgs', 'DEFAULT_TARGET_ORG', '--no-telemetry', '--allow-non-ga-tools']
+                args: ['--toolsets', 'code-analysis', '--orgs', 'DEFAULT_TARGET_ORG', '--no-telemetry', '--allow-non-ga-tools']
             });
             await client.connect(transport);
         } catch (error) {

--- a/packages/mcp-provider-code-analyzer/test/e2e/run_code_analyzer-e2e.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/e2e/run_code_analyzer-e2e.test.ts
@@ -20,7 +20,7 @@ describe('run_code_analyzer', () => {
     beforeAll(async () => {
         try {
             const transport = DxMcpTransport({
-                args: ['--toolsets', 'all', '--orgs', 'DEFAULT_TARGET_ORG', '--no-telemetry', '--allow-non-ga-tools']
+                args: ['--toolsets', 'code-analysis', '--orgs', 'DEFAULT_TARGET_ORG', '--no-telemetry', '--allow-non-ga-tools']
             });
             await client.connect(transport);
         } catch (error) {
@@ -52,7 +52,7 @@ describe('run_code_analyzer', () => {
             params: {
                 target: [target]
             }
-        });
+        }, 60000);
 
         expect(result.structuredContent!.status).toEqual('success');
         expect(result.structuredContent!.summary).toHaveProperty('total', expectedCount);
@@ -67,5 +67,5 @@ describe('run_code_analyzer', () => {
         });
 
         expect(result.structuredContent!.status).toContain('All targeted files must exist, but ');
-    })
+    }, 60000)
 })

--- a/packages/mcp-provider-code-analyzer/test/e2e/run_code_analyzer-e2e.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/e2e/run_code_analyzer-e2e.test.ts
@@ -1,0 +1,71 @@
+import path from 'node:path';
+import { fileURLToPath } from "url";
+import { z } from 'zod';
+import { McpTestClient, DxMcpTransport } from '@salesforce/mcp-test-client';
+import { inputSchema } from '../../src/tools/run_code_analyzer.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('run_code_analyzer', () => {
+    const client = new McpTestClient({
+        timeout: 60000
+    });
+
+    const testInputSchema = {
+        name: z.literal('run_code_analyzer'),
+        params: inputSchema
+    };
+
+    beforeAll(async () => {
+        try {
+            const transport = DxMcpTransport({
+                args: ['--toolsets', 'all', '--orgs', 'DEFAULT_TARGET_ORG', '--no-telemetry', '--allow-non-ga-tools']
+            });
+            await client.connect(transport);
+        } catch (error) {
+            console.error('Setup failed:', error);
+            throw error;
+        }
+    });
+
+    afterAll(async () => {
+        if (client?.connected) {
+            await client.disconnect();
+        }
+    });
+
+    it.each([
+        {
+            case: 'violations are present',
+            target: path.join(__dirname, '..', 'fixtures', 'sample-targets', 'ApexTarget2.cls'),
+            expectedCount: 6
+        },
+        {
+            case: 'no violations are present',
+            target: path.join(__dirname, '..', 'fixtures', 'sample-targets', 'ApexTarget1.cls'),
+            expectedCount: 0
+        }
+    ])('when $case, returns correct violation summary', async ({target, expectedCount}) => {
+        const result = await client.callTool(testInputSchema, {
+            name: 'run_code_analyzer',
+            params: {
+                target: [target]
+            }
+        });
+
+        expect(result.structuredContent!.status).toEqual('success');
+        expect(result.structuredContent!.summary).toHaveProperty('total', expectedCount);
+    });
+
+    it('errors when non-existent file is targeted', async () => {
+        const result = await client.callTool(testInputSchema, {
+            name: 'run_code_analyzer',
+            params: {
+                target: [path.join(__dirname, '..', 'fixtures', 'sample-targets', 'NoTargetWithThisName.cls')]
+            }
+        });
+
+        expect(result.structuredContent!.status).toContain('All targeted files must exist, but ');
+    })
+})


### PR DESCRIPTION
### What does this PR do?

It uses the end-to-end test framework added in #185 to add e2e test coverage for the code analyzer tools.

### What issues does this PR fix or reference?
@W-19450490@ (There will likely be an additional PR associated with this work item, since we also want to implement `eval`-based tests as well.)