### PR TITLE
W-19785029: disable telem for local dev

### DIFF
--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -4,16 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       update-providers:
-        description: 'Update provider dependencies to latest versions'
+        description: "Update provider dependencies to latest versions"
         type: boolean
         default: false
       providers-to-update:
-        description: 'Comma-separated list of providers to update (leave empty to update all)'
+        description: "Comma-separated list of providers to update (leave empty to update all)"
         type: string
-        default: ''
+        default: ""
       prerelease:
         type: string
-        description: 'Name to use for the prerelease: beta, dev, etc.'
+        description: "Name to use for the prerelease: beta, dev, etc."
 
 jobs:
   update-dependencies:
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: "lts/*"
           cache: yarn
 
       - name: Update provider dependencies
@@ -129,17 +129,30 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: "lts/*"
           cache: yarn
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+        # NOTE: This step must be before the "Build package" step
+      - name: Replace AppInsights Key
+        run: |
+          # Replace the empty APP_INSIGHTS_KEY with the actual key from secrets
+          sed -i "s|const APP_INSIGHTS_KEY = '';|const APP_INSIGHTS_KEY = '$APP_INSIGHTS_KEY';|" packages/mcp/src/telemetry.ts
+
+          if grep -q "applicationinsights.azure.com" packages/mcp/src/telemetry.ts; then
+            echo "✅ AppInsights key successfully replaced"
+          else
+            echo "❌ AppInsights key replacement failed"
+            exit 1
+          fi
+        env:
+          APP_INSIGHTS_KEY: ${{ secrets.APP_INSIGHTS_KEY }}
       - name: Build package
         run: |
           # build the whole monorepo to get a provider-api build to for other dependant code
           yarn build
-
       - name: Conventional Changelog Action
         id: changelog
         uses: TriPSs/conventional-changelog-action@3a392e9aa44a72686b0fc13259a90d287dd0877c
@@ -197,10 +210,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         command:
-          - 'yarn test:e2e'
+          - "yarn test:e2e"
         provider:
-          - 'mcp-provider-dx-core'
-          - 'mcp-provider-code-analyzer'
+          - "mcp-provider-dx-core"
+          - "mcp-provider-code-analyzer"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -210,4 +223,3 @@ jobs:
           command: ${{ matrix.command }}
           provider: ${{ matrix.provider }}
           dxMcpVersion: ${{ needs.publish-server.outputs.version }}
-

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -23,8 +23,9 @@ import { Config } from '@oclif/core';
 import { TelemetryService } from '@salesforce/mcp-provider-api/src/index.js';
 
 const PROJECT = 'salesforce-mcp-server';
-const APP_INSIGHTS_KEY =
-  'InstrumentationKey=2ca64abb-6123-4c7b-bd9e-4fe73e71fe9c;IngestionEndpoint=https://eastus-1.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=ecd8fa7a-0e0d-4109-94db-4d7878ada862';
+// WARN: This is intentionally empty! It's populated at the time of publish
+//       This is to prevent telemetry pollution from local clones and forks
+const APP_INSIGHTS_KEY = '';
 
 const generateRandomId = (): string => randomBytes(20).toString('hex');
 
@@ -75,9 +76,11 @@ export class Telemetry implements TelemetryService {
   private reporter?: McpTelemetryReporter;
 
   public constructor(private readonly config: Config, private attributes: Attributes = {}) {
-    warn(
-      'You acknowledge and agree that the MCP server may collect usage information, user environment, and crash reports for the purposes of providing services or functions that are relevant to use of the MCP server and product improvements.'
-    );
+    const startupMessage = APP_INSIGHTS_KEY
+      ? 'You acknowledge and agree that the MCP server may collect usage information, user environment, and crash reports for the purposes of providing services or functions that are relevant to use of the MCP server and product improvements.'
+      : 'Telemetry is automatically disabled for local development.'
+
+    warn(startupMessage);
     this.sessionId = generateRandomId();
     this.cliId = getCliId(config.cacheDir);
   }
@@ -113,6 +116,7 @@ export class Telemetry implements TelemetryService {
 
   public async start(): Promise<void> {
     if (this.started) return;
+    if (!APP_INSIGHTS_KEY) return;
     this.started = true;
 
     try {


### PR DESCRIPTION
### What does this PR do?
Disables telemetry for local clones and forks. The app insights key is injected at the time of publish

Note: if you test this on a mac, the `sed` command needs the flag `-i.bak` or `-i ''`

### What issues does this PR fix or reference?
[@W-19785029@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-19785029)
