### PR TITLE
Standardize error handling for DevOps work item flows

### DIFF
--- a/packages/mcp-provider-devops/src/getWorkItems.ts
+++ b/packages/mcp-provider-devops/src/getWorkItems.ts
@@ -118,7 +118,7 @@ export async function fetchWorkItems(username: string, projectId: string): Promi
         }
         return [];
     } catch (error) {
-        return error;
+        throw error;
     }
 }
 
@@ -160,7 +160,7 @@ export async function fetchWorkItemByName(username: string, workItemName: string
         }
         return mapRawItemToWorkItem(item, ctx);
     } catch (error) {
-        return error;
+        throw error;
     }
 }
 
@@ -222,6 +222,6 @@ export async function fetchWorkItemsByNames(username: string, workItemNames: str
 
         return workItems;
     } catch (error) {
-        return error;
+        throw error;
     }
 }

--- a/packages/mcp-provider-devops/src/tools/createPullRequest.ts
+++ b/packages/mcp-provider-devops/src/tools/createPullRequest.ts
@@ -87,7 +87,7 @@ export class CreatePullRequest extends McpTool<InputArgsShape, OutputArgsShape> 
         return {
           content: [{
             type: "text",
-            text: `Error: Work item Name is required. Please provide a valid work item Name.`
+            text: `Error: Work item Name is required. Please provide a valid work item Name. Or provide a valid DevOps Center org username.`
           }]
         };
       }

--- a/packages/mcp-provider-devops/src/tools/sfDevopsCheckoutWorkItem.ts
+++ b/packages/mcp-provider-devops/src/tools/sfDevopsCheckoutWorkItem.ts
@@ -89,13 +89,30 @@ This tool takes the DevOps Center org username and the exact Work Item Name, loo
       };
     }
 
-    const workItem = await fetchWorkItemByName(input.username, input.workItemName);
-    
+    let workItem: any;
+    try {
+      workItem = await fetchWorkItemByName(input.username, input.workItemName);
+    } catch (e: any) {
+      return {
+        content: [{ type: "text", text: `Error fetching work item: ${e?.message || e}` }],
+        isError: true
+      };
+    }
+
+    if (!workItem) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error: Work item not found. Please provide a valid work item name or valid DevOps Center org username.`
+        }]
+      };
+    }
+
     if (!workItem?.SourceCodeRepository?.repoUrl || !workItem?.WorkItemBranch) {
       return {
         content: [{
           type: "text",
-          text: "Work item is missing required repository URL or branch information"
+          text: `Work item is missing required repository URL or branch information  ${workItem}`
         }],
         isError: true
       };

--- a/packages/mcp-provider-devops/src/tools/sfDevopsCommitWorkItem.ts
+++ b/packages/mcp-provider-devops/src/tools/sfDevopsCommitWorkItem.ts
@@ -110,7 +110,7 @@ When user asks to "commit work item" or "commit changes", DO NOT use this tool d
         return {
           content: [{
             type: "text",
-            text: `Error: Work item Name is required. Please provide a work item with an Name.`
+            text: `Error: Work item Name is required. Please provide a work item with an Name. Or provide a valid DevOps Center org username.`
           }]
         };
       }

--- a/packages/mcp-provider-devops/src/tools/sfDevopsCommitWorkItem.ts
+++ b/packages/mcp-provider-devops/src/tools/sfDevopsCommitWorkItem.ts
@@ -110,7 +110,7 @@ When user asks to "commit work item" or "commit changes", DO NOT use this tool d
         return {
           content: [{
             type: "text",
-            text: `Error: Work item Name is required. Please provide a work item with an Name. Or provide a valid DevOps Center org username.`
+            text: `Error: Work Item Name is required. Please provide a valid Work Item Name or a valid DevOps Center org username.`
           }]
         };
       }

--- a/packages/mcp-provider-devops/src/tools/sfDevopsDetectConflict.ts
+++ b/packages/mcp-provider-devops/src/tools/sfDevopsDetectConflict.ts
@@ -70,10 +70,28 @@ export class SfDevopsDetectConflict extends McpTool<InputArgsShape, OutputArgsSh
 
   public async exec(input: InputArgs): Promise<CallToolResult> {
     const isMP = await isManagedPackageDevopsOrg(input.username);
-    const workItem = isMP 
-      ? await fetchWorkItemByNameMP(input.username, input.workItemName)
-      : await fetchWorkItemByName(input.username, input.workItemName);
+    let workItem: any;
+    try {
+      workItem = isMP 
+        ? await fetchWorkItemByNameMP(input.username, input.workItemName)
+        : await fetchWorkItemByName(input.username, input.workItemName);
+    } catch (e: any) {
+      return {
+        content: [{ type: "text", text: `Error fetching work item: ${e?.message || e}` }],
+        isError: true
+      };
+    }
     
+
+    if (!workItem) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error: Work item not found. Please provide a valid work item name or valid DevOps Center org username.`
+        }]
+      };
+    }
+
     if (!input.localPath || input.localPath.trim().length === 0) {
       return {
         content: [{

--- a/packages/mcp-provider-devops/src/tools/sfDevopsListWorkItems.ts
+++ b/packages/mcp-provider-devops/src/tools/sfDevopsListWorkItems.ts
@@ -58,12 +58,19 @@ export class SfDevopsListWorkItems extends McpTool<InputArgsShape, OutputArgsSha
   }
 
   public async exec(input: InputArgs): Promise<CallToolResult> {
-    const workItems = await fetchWorkItems(input.username, input.project.Id);
-    return {
-      content: [{
-        type: "text",
-        text: JSON.stringify(workItems, null, 2)
-      }]
-    };
+    try {
+      const workItems = await fetchWorkItems(input.username, input.project.Id);
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(workItems, null, 2)
+        }]
+      };
+    } catch (e: any) {
+      return {
+        content: [{ type: "text", text: `Error listing work items: ${e?.message || e}` }],
+        isError: true
+      };
+    }
   }
 }

--- a/packages/mcp-provider-devops/src/tools/sfDevopsPromoteWorkItem.ts
+++ b/packages/mcp-provider-devops/src/tools/sfDevopsPromoteWorkItem.ts
@@ -77,7 +77,12 @@ export class SfDevopsPromoteWorkItem extends McpTool<InputArgsShape, OutputArgsS
   }
 
   public async exec(input: InputArgs): Promise<CallToolResult> {
-    const items = await fetchWorkItemsByNames(input.username, input.workItemNames);
+    let items: any[] | any;
+    try {
+      items = await fetchWorkItemsByNames(input.username, input.workItemNames);
+    } catch (e: any) {
+      return { content: [{ type: "text", text: `Error fetching work items: ${e?.message || e}` }], isError: true };
+    }
     if (!Array.isArray(items) || items.length === 0) {
       return { content: [{ type: "text", text: "No matching Work Items found for provided names." }] };
     }

--- a/packages/mcp-provider-devops/src/tools/sfDevopsResolveConflict.ts
+++ b/packages/mcp-provider-devops/src/tools/sfDevopsResolveConflict.ts
@@ -69,10 +69,27 @@ export class SfDevopsResolveConflict extends McpTool<InputArgsShape, OutputArgsS
 
   public async exec(input: InputArgs): Promise<CallToolResult> {
     const isMP = await isManagedPackageDevopsOrg(input.username);
-    const workItem = isMP 
-      ? await fetchWorkItemByNameMP(input.username, input.workItemName)
-      : await fetchWorkItemByName(input.username, input.workItemName);
+    let workItem: any;
+    try {
+      workItem = isMP 
+        ? await fetchWorkItemByNameMP(input.username, input.workItemName)
+        : await fetchWorkItemByName(input.username, input.workItemName);
+    } catch (e: any) {
+      return {
+        content: [{ type: "text", text: `Error fetching work item: ${e?.message || e}` }],
+        isError: true
+      };
+    }
     
+    if (!workItem) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error: Work item not found. Please provide a valid work item name or valid DevOps Center org username.`
+        }]
+      };
+    }
+
     if (!input.localPath || input.localPath.trim().length === 0) {
       return {
         content: [{


### PR DESCRIPTION
### What:
Switch getWorkItems.ts to throw errors instead of returning them (fetchWorkItems, fetchWorkItemByName, fetchWorkItemsByNames).
Add try/catch around these calls in tools: sfDevopsCheckoutWorkItem, sfDevopsDetectConflict, sfDevopsResolveConflict, sfDevopsListWorkItems, sfDevopsPromoteWorkItem, returning concise, user-friendly error messages.

### Why:
getConnection rejects with an Error; returning error objects downstream caused inconsistent types and confusing flows. Throwing enforces explicit handling and cleaner UX.

### Impact:
No change on success paths.
Clearer, consistent error responses on failures.
Callers updated accordingly; lints pass.

### Validation:
Lint clean.
all tests passed