### PR TITLE
chore(ci): debug publish workflow W-19756811 

### DIFF
--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -214,7 +214,6 @@ jobs:
 
   e2e-test:
     needs: [publish-server]
-    if: ${{ needs.publish-server.outputs.skipped == 'false' }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -226,9 +225,15 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Debug publish-server outputs
+        run: |
+          echo "publish-server outputs:"
+          echo "  skipped: ${{ needs.publish-server.outputs.skipped }}"
+          echo "  release-id: ${{ needs.publish-server.outputs.release-id }}"
+          echo "  version: ${{ needs.publish-server.outputs.version }}"
       - uses: ./.github/workflows/e2e.yml
         with:
           os: ${{ matrix.os }}
           command: ${{ matrix.command }}
           provider: ${{ matrix.provider }}
-          dxMcpVersion: ${{ needs.publish-server.outputs.version }}
+          dxMcpVersion: ${{ needs.publish-server.outputs.version || 'rc' }}


### PR DESCRIPTION
### What does this PR do?

update publish workflow to print the expected job output variables from `publish-server` in `e2e-test`, it's currently being skipped in releases:

<img width="483" height="407" alt="Screenshot 2025-10-01 at 18 52 36" src="https://github.com/user-attachments/assets/5ec30aee-b988-4d75-8c80-22b110c1bf30" />


Also add a fallback for `dxMcpVersion` to `rc` now that we publish to `rc` first.

### What issues does this PR fix or reference?
@W-19756811@