### PR TITLE
Fix incorrect tool name in mcp.json example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Here's an example for VS Code with Copilot in which you create and update a `.vs
          "args": ["-y", "@salesforce/mcp", 
          "--orgs", "DEFAULT_TARGET_ORG", 
          "--toolsets", "orgs,metadata,data,users",
-         "--tools", "run_apex_tests",
+         "--tools", "run_apex_test",
          "--allow-non-ga-tools"]
        }
      }


### PR DESCRIPTION
### What does this PR do?
`run_apex_tests` does not exist so this command will fail. `run_apex_test` is currently the correct string.

### What issues does this PR fix or reference?
No idea if there is an internal one for this.