### PR TITLE
Refactor commit status logic and strengthen SFDX commit guidance

### DIFF
--- a/packages/mcp-provider-devops/src/getCommitStatus.ts
+++ b/packages/mcp-provider-devops/src/getCommitStatus.ts
@@ -1,0 +1,40 @@
+import axios from "axios";
+import { getConnection } from "./shared/auth.js";
+
+export interface CommitStatusResult {
+  requestId: string;
+  status: string;
+  recordId?: string;
+  message: string;
+}
+
+export async function fetchCommitStatus(username: string, requestId: string): Promise<CommitStatusResult> {
+  const connection = await getConnection(username);
+  const query = `SELECT Id, Status__c, RequestToken__c FROM DevopsRequestInfo WHERE RequestToken__c = '${requestId}' LIMIT 1`;
+
+  const response = await axios.get(`${connection.instanceUrl}/services/data/v65.0/query`, {
+    headers: {
+      'Authorization': `Bearer ${connection.accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    params: { q: query }
+  });
+
+  if (response.data.records && response.data.records.length > 0) {
+    const record = response.data.records[0];
+    return {
+      requestId,
+      status: record.Status__c,
+      recordId: record.Id,
+      message: `Request ${requestId} has status: ${record.Status__c}`
+    };
+  }
+
+  return {
+    requestId,
+    status: 'NOT_FOUND',
+    message: `No record found for request ID: ${requestId}`
+  };
+}
+
+

--- a/packages/mcp-provider-devops/src/tools/checkCommitStatus.ts
+++ b/packages/mcp-provider-devops/src/tools/checkCommitStatus.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { McpTool, McpToolConfig, ReleaseState, Toolset, TelemetryService } from "@salesforce/mcp-provider-api";
-import axios from "axios";
-import { getConnection } from "../shared/auth.js";
+import { fetchCommitStatus } from "../getCommitStatus.js";
 
 const inputSchema = z.object({
   username: z.string().describe("Username of the DevOps Center org"),
@@ -56,44 +55,13 @@ export class CheckCommitStatus extends McpTool<InputArgsShape, OutputArgsShape> 
 
   public async exec(input: InputArgs): Promise<CallToolResult> {
     try {
-      const connection = await getConnection(input.username);
-      const query = `SELECT Id, Status__c, RequestToken__c FROM DevopsRequestInfo WHERE RequestToken__c = '${input.requestId}' LIMIT 1`;
-      
-      const response = await axios.get(`${connection.instanceUrl}/services/data/v60.0/query`, {
-        headers: {
-          'Authorization': `Bearer ${connection.accessToken}`,
-          'Content-Type': 'application/json'
-        },
-        params: { q: query }
-      });
-
-      if (response.data.records && response.data.records.length > 0) {
-        const record = response.data.records[0];
-        const status = {
-          requestId: input.requestId,
-          status: record.Status__c,
-          recordId: record.Id,
-          message: `Request ${input.requestId} has status: ${record.Status__c}`
-        };
-        return {
-          content: [{
-            type: "text",
-            text: JSON.stringify(status, null, 2)
-          }]
-        };
-      } else {
-        const status = {
-          requestId: input.requestId,
-          status: 'NOT_FOUND',
-          message: `No record found for request ID: ${input.requestId}`
-        };
-        return {
-          content: [{
-            type: "text",
-            text: JSON.stringify(status, null, 2)
-          }]
-        };
-      }
+      const status = await fetchCommitStatus(input.username, input.requestId);
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(status, null, 2)
+        }]
+      };
     } catch (error: any) {
       return {
         content: [{

--- a/packages/mcp-provider-devops/src/tools/sfDevopsCommitWorkItem.ts
+++ b/packages/mcp-provider-devops/src/tools/sfDevopsCommitWorkItem.ts
@@ -47,6 +47,8 @@ When user asks to "commit work item" or "commit changes", DO NOT use this tool d
 
 **THIS TOOL IS ONLY USED AS THE FINAL STEP AFTER COMPLETING ALL PREREQUISITES**
 
+**CRITICAL:** Never use \`git commit\` to commit SFDX project changes. Always use commit_devops_center_work_item tool to commit SFDX project changes so DevOps Center correctly tracks metadata and ties commits to Work Items.
+
 **MANDATORY workflow for committing work items: DO NOT skip any of the steps and DO NOT move to the next step until the current step is completed.**
 1. **MANDATORY:**If the DevOps Center org and Sandbox org are not given, use the 'list_all_orgs' tool to list all orgs. 
    The list will indicate which org is DevOps Center and a Sandbox. If BOTH these details are not provided in the list, then


### PR DESCRIPTION
- Extracted commit status logic to src/getCommitStatus.ts (fetchCommitStatus).
- Refactored src/tools/checkCommitStatus.ts to use the shared helper (no behavior change).
- Updated src/tools/sfDevopsCommitWorkItem.ts description to explicitly state: never use git commit for SFDX; always use commit_devops_center_work_item.

### Rationale

- Aligns with existing pattern (getProjects.ts, getWorkItems.ts) for reusability and testability.
- Clarifies correct workflow so DevOps Center properly tracks metadata and ties commits to Work Items.