### PR TITLE
@W-21740433 - feat: add PdpEvent type and sendPdpEvent method to TelemetryService

### DIFF
--- a/packages/mcp-provider-api/src/index.ts
+++ b/packages/mcp-provider-api/src/index.ts
@@ -14,6 +14,7 @@ export {
   type Services,
   type TelemetryService,
   type TelemetryEvent,
+  type PdpEvent,
   type OrgService,
   type ConfigService,
   type StartupFlags

--- a/packages/mcp-provider-api/src/services.ts
+++ b/packages/mcp-provider-api/src/services.ts
@@ -9,10 +9,18 @@ export interface Services {
 
 export interface TelemetryService {
   sendEvent(eventName: string, event: TelemetryEvent): void;
+  sendPdpEvent(event: PdpEvent): void;
 }
 
 export type TelemetryEvent = {
   [key: string]: string | number | boolean | null | undefined;
+};
+
+export type PdpEvent = {
+  eventName: `${string}.${string}`;
+  productFeatureId: `aJC${string}`;
+  componentId?: string;
+  eventVolume?: number;
 };
 
 

--- a/packages/mcp/src/services.ts
+++ b/packages/mcp/src/services.ts
@@ -17,6 +17,7 @@ import {
   Services as IServices,
   TelemetryService,
   TelemetryEvent,
+  PdpEvent,
   OrgService,
   SanitizedOrgAuthorization,
   ConfigService,
@@ -68,6 +69,10 @@ export class Services implements IServices {
 
 class NoopTelemetryService implements TelemetryService {
   public sendEvent(_eventName: string, _event: TelemetryEvent): void {
+    // no-op
+  }
+
+  public sendPdpEvent(_event: PdpEvent): void {
     // no-op
   }
 }


### PR DESCRIPTION
Adds Product Feedback Telemetry (PFT) support to the MCP Provider API to enable PDP event reporting across all MCP provider packages.

Changes:
- Added PdpEvent type with template literal constraints:
  * eventName: enforces "object.action" format (e.g., "codeAnalyzer.run")
  * productFeatureId: enforces GUS Product Feature ID format (aJC prefix)
  * componentId: optional component identifier
  * eventVolume: optional volume metric
- Added sendPdpEvent() method to TelemetryService interface
- Exported PdpEvent type from package index

The PdpEvent type aligns with @salesforce/telemetry package's type definitions, ensuring type safety and compatibility with O11y telemetry infrastructure.

This API change enables provider packages to send PFT events for product analytics and usage tracking.

### What does this PR do?

### What issues does this PR fix or reference?
