### PR TITLE
@W-21974851: feat- Add workingDirectory parameter and fix selector rule name support

### DIFF
--- a/packages/mcp-provider-code-analyzer/src/actions/run-analyzer.ts
+++ b/packages/mcp-provider-code-analyzer/src/actions/run-analyzer.ts
@@ -28,10 +28,9 @@ type RunAnalyzerActionOptions = {
     telemetryService?: TelemetryService
 }
 
-// NOTE: THIS MUST ALIGN WITH THE ZOD SCHEMA DEFINED IN `tools/run_code_analyzer.ts`.
 export type RunInput = {
     target: string[]
-    workingDirectory: string
+    directory: string
     selector?: string
     configPath?: string
 }
@@ -61,7 +60,7 @@ export class RunAnalyzerActionImpl implements RunAnalyzerAction {
     public async exec(input: RunInput): Promise<RunOutput> {
         let analyzer: CodeAnalyzer;
         try {
-            analyzer = new CodeAnalyzer(this.configFactory.create(input.configPath, input.workingDirectory));
+            analyzer = new CodeAnalyzer(this.configFactory.create(input.configPath, input.directory));
         } catch (e) {
             return {
                 status: getMessage('errorCreatingConfig', getErrorMessage(e))

--- a/packages/mcp-provider-code-analyzer/src/actions/run-analyzer.ts
+++ b/packages/mcp-provider-code-analyzer/src/actions/run-analyzer.ts
@@ -31,6 +31,7 @@ type RunAnalyzerActionOptions = {
 // NOTE: THIS MUST ALIGN WITH THE ZOD SCHEMA DEFINED IN `tools/run_code_analyzer.ts`.
 export type RunInput = {
     target: string[]
+    workingDirectory: string
     selector?: string
     configPath?: string
 }
@@ -60,7 +61,7 @@ export class RunAnalyzerActionImpl implements RunAnalyzerAction {
     public async exec(input: RunInput): Promise<RunOutput> {
         let analyzer: CodeAnalyzer;
         try {
-            analyzer = new CodeAnalyzer(this.configFactory.create(input.configPath));
+            analyzer = new CodeAnalyzer(this.configFactory.create(input.configPath, input.workingDirectory));
         } catch (e) {
             return {
                 status: getMessage('errorCreatingConfig', getErrorMessage(e))

--- a/packages/mcp-provider-code-analyzer/src/actions/run-analyzer.ts
+++ b/packages/mcp-provider-code-analyzer/src/actions/run-analyzer.ts
@@ -32,6 +32,7 @@ type RunAnalyzerActionOptions = {
 export type RunInput = {
     target: string[]
     selector?: string
+    configPath?: string
 }
 
 // NOTE: THIS MUST ALIGN WITH THE ZOD SCHEMA DEFINED IN `tools/run_code_analyzer.ts`.
@@ -59,7 +60,7 @@ export class RunAnalyzerActionImpl implements RunAnalyzerAction {
     public async exec(input: RunInput): Promise<RunOutput> {
         let analyzer: CodeAnalyzer;
         try {
-            analyzer = new CodeAnalyzer(this.configFactory.create());
+            analyzer = new CodeAnalyzer(this.configFactory.create(input.configPath));
         } catch (e) {
             return {
                 status: getMessage('errorCreatingConfig', getErrorMessage(e))

--- a/packages/mcp-provider-code-analyzer/src/factories/CodeAnalyzerConfigFactory.ts
+++ b/packages/mcp-provider-code-analyzer/src/factories/CodeAnalyzerConfigFactory.ts
@@ -7,9 +7,6 @@ export interface CodeAnalyzerConfigFactory {
 }
 
 export class CodeAnalyzerConfigFactoryImpl {
-    private static readonly CONFIG_FILE_NAME: string = "code-analyzer";
-    private static readonly CONFIG_FILE_EXTENSIONS: string[] = ['yaml', 'yml'];
-
     public create(configPath?: string): CodeAnalyzerConfig {
         // If a config path is explicitly provided, use it
         if (configPath) {
@@ -22,17 +19,7 @@ export class CodeAnalyzerConfigFactoryImpl {
             return CodeAnalyzerConfig.fromFile(configPath);
         }
 
-        // Otherwise, seek config in current directory
-        return this.seekConfigInCurrentDirectory() ?? CodeAnalyzerConfig.withDefaults();
-    }
-
-    private seekConfigInCurrentDirectory(): CodeAnalyzerConfig | undefined {
-        for (const ext of CodeAnalyzerConfigFactoryImpl.CONFIG_FILE_EXTENSIONS) {
-            const possibleConfigFilePath: string = path.resolve(`${CodeAnalyzerConfigFactoryImpl.CONFIG_FILE_NAME}.${ext}`);
-            if (fs.existsSync(possibleConfigFilePath)) {
-                return CodeAnalyzerConfig.fromFile(possibleConfigFilePath);
-            }
-        }
-        return undefined;
+        // If no config path provided, use defaults (ignore any config files in current directory)
+        return CodeAnalyzerConfig.withDefaults();
     }
 }

--- a/packages/mcp-provider-code-analyzer/src/factories/CodeAnalyzerConfigFactory.ts
+++ b/packages/mcp-provider-code-analyzer/src/factories/CodeAnalyzerConfigFactory.ts
@@ -1,20 +1,21 @@
 import path from "node:path";
 import fs from "node:fs";
 import { CodeAnalyzerConfig } from "@salesforce/code-analyzer-core";
+import { sanitizePath } from "../utils.js";
 
 export interface CodeAnalyzerConfigFactory {
-    create(configPath?: string, workingDirectory?: string): CodeAnalyzerConfig;
+    create(configPath?: string, directory?: string): CodeAnalyzerConfig;
 }
 
 export class CodeAnalyzerConfigFactoryImpl {
     private static readonly CONFIG_FILE_NAME: string = "code-analyzer";
     private static readonly CONFIG_FILE_EXTENSIONS: string[] = ['yaml', 'yml'];
 
-    public create(configPath?: string, workingDirectory?: string): CodeAnalyzerConfig {
+    public create(configPath?: string, directory?: string): CodeAnalyzerConfig {
         // Priority 1: If a config path is explicitly provided, use it
         if (configPath) {
-            if (!path.isAbsolute(configPath)) {
-                throw new Error(`Config path must be an absolute path: ${configPath}`);
+            if (!sanitizePath(configPath)) {
+                throw new Error(`Invalid config path: ${configPath}. Path must be absolute and not contain traversal sequences.`);
             }
             if (!fs.existsSync(configPath)) {
                 throw new Error(`Specified config file does not exist: ${configPath}`);
@@ -22,20 +23,20 @@ export class CodeAnalyzerConfigFactoryImpl {
             return CodeAnalyzerConfig.fromFile(configPath);
         }
 
-        // Priority 2: If workingDirectory is provided, search for config files there
-        if (workingDirectory) {
-            if (!path.isAbsolute(workingDirectory)) {
-                throw new Error(`Working directory must be an absolute path: ${workingDirectory}`);
+        // Priority 2: If directory is provided, search for config files there
+        if (directory) {
+            if (!sanitizePath(directory)) {
+                throw new Error(`Invalid directory path: ${directory}. Path must be absolute and not contain traversal sequences.`);
             }
-            if (!fs.existsSync(workingDirectory)) {
-                throw new Error(`Working directory does not exist: ${workingDirectory}`);
+            if (!fs.existsSync(directory)) {
+                throw new Error(`Directory does not exist: ${directory}`);
             }
-            if (!fs.statSync(workingDirectory).isDirectory()) {
-                throw new Error(`Working directory must be a directory, not a file: ${workingDirectory}`);
+            if (!fs.statSync(directory).isDirectory()) {
+                throw new Error(`Directory must be a directory, not a file: ${directory}`);
             }
-            const configFromWorkingDir = this.seekConfigInDirectory(workingDirectory);
-            if (configFromWorkingDir) {
-                return configFromWorkingDir;
+            const configFromDirectory = this.seekConfigInDirectory(directory);
+            if (configFromDirectory) {
+                return configFromDirectory;
             }
         }
 

--- a/packages/mcp-provider-code-analyzer/src/factories/CodeAnalyzerConfigFactory.ts
+++ b/packages/mcp-provider-code-analyzer/src/factories/CodeAnalyzerConfigFactory.ts
@@ -3,12 +3,15 @@ import fs from "node:fs";
 import { CodeAnalyzerConfig } from "@salesforce/code-analyzer-core";
 
 export interface CodeAnalyzerConfigFactory {
-    create(configPath?: string): CodeAnalyzerConfig;
+    create(configPath?: string, workingDirectory?: string): CodeAnalyzerConfig;
 }
 
 export class CodeAnalyzerConfigFactoryImpl {
-    public create(configPath?: string): CodeAnalyzerConfig {
-        // If a config path is explicitly provided, use it
+    private static readonly CONFIG_FILE_NAME: string = "code-analyzer";
+    private static readonly CONFIG_FILE_EXTENSIONS: string[] = ['yaml', 'yml'];
+
+    public create(configPath?: string, workingDirectory?: string): CodeAnalyzerConfig {
+        // Priority 1: If a config path is explicitly provided, use it
         if (configPath) {
             if (!path.isAbsolute(configPath)) {
                 throw new Error(`Config path must be an absolute path: ${configPath}`);
@@ -19,7 +22,34 @@ export class CodeAnalyzerConfigFactoryImpl {
             return CodeAnalyzerConfig.fromFile(configPath);
         }
 
-        // If no config path provided, use defaults (ignore any config files in current directory)
+        // Priority 2: If workingDirectory is provided, search for config files there
+        if (workingDirectory) {
+            if (!path.isAbsolute(workingDirectory)) {
+                throw new Error(`Working directory must be an absolute path: ${workingDirectory}`);
+            }
+            if (!fs.existsSync(workingDirectory)) {
+                throw new Error(`Working directory does not exist: ${workingDirectory}`);
+            }
+            if (!fs.statSync(workingDirectory).isDirectory()) {
+                throw new Error(`Working directory must be a directory, not a file: ${workingDirectory}`);
+            }
+            const configFromWorkingDir = this.seekConfigInDirectory(workingDirectory);
+            if (configFromWorkingDir) {
+                return configFromWorkingDir;
+            }
+        }
+
+        // Priority 3: Use defaults
         return CodeAnalyzerConfig.withDefaults();
+    }
+
+    private seekConfigInDirectory(directory: string): CodeAnalyzerConfig | undefined {
+        for (const ext of CodeAnalyzerConfigFactoryImpl.CONFIG_FILE_EXTENSIONS) {
+            const possibleConfigFilePath: string = path.join(directory, `${CodeAnalyzerConfigFactoryImpl.CONFIG_FILE_NAME}.${ext}`);
+            if (fs.existsSync(possibleConfigFilePath)) {
+                return CodeAnalyzerConfig.fromFile(possibleConfigFilePath);
+            }
+        }
+        return undefined;
     }
 }

--- a/packages/mcp-provider-code-analyzer/src/factories/CodeAnalyzerConfigFactory.ts
+++ b/packages/mcp-provider-code-analyzer/src/factories/CodeAnalyzerConfigFactory.ts
@@ -3,14 +3,26 @@ import fs from "node:fs";
 import { CodeAnalyzerConfig } from "@salesforce/code-analyzer-core";
 
 export interface CodeAnalyzerConfigFactory {
-    create(): CodeAnalyzerConfig;
+    create(configPath?: string): CodeAnalyzerConfig;
 }
 
 export class CodeAnalyzerConfigFactoryImpl {
     private static readonly CONFIG_FILE_NAME: string = "code-analyzer";
     private static readonly CONFIG_FILE_EXTENSIONS: string[] = ['yaml', 'yml'];
 
-    public create(): CodeAnalyzerConfig {
+    public create(configPath?: string): CodeAnalyzerConfig {
+        // If a config path is explicitly provided, use it
+        if (configPath) {
+            if (!path.isAbsolute(configPath)) {
+                throw new Error(`Config path must be an absolute path: ${configPath}`);
+            }
+            if (!fs.existsSync(configPath)) {
+                throw new Error(`Specified config file does not exist: ${configPath}`);
+            }
+            return CodeAnalyzerConfig.fromFile(configPath);
+        }
+
+        // Otherwise, seek config in current directory
         return this.seekConfigInCurrentDirectory() ?? CodeAnalyzerConfig.withDefaults();
     }
 

--- a/packages/mcp-provider-code-analyzer/src/tools/create_custom_rule.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/create_custom_rule.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { McpTool, McpToolConfig, ReleaseState, Toolset, TelemetryService } from "@salesforce/mcp-provider-api";
 import * as Constants from "../constants.js";
+import { sanitizePath } from "../utils.js";
 import {
   CreateXpathCustomRuleAction,
   CreateXpathCustomRuleActionImpl,
@@ -163,6 +164,10 @@ function validateInput(input: z.infer<typeof inputSchema>): CallToolResult | und
   const workingDirectory = input.workingDirectory?.trim();
   if (!workingDirectory) {
     return buildError("workingDirectory is required. Provide a directory where files can be written.");
+  }
+
+  if (!sanitizePath(workingDirectory)) {
+    return buildError(`Invalid workingDirectory path: ${workingDirectory}. Path must be absolute and not contain traversal sequences.`);
   }
 
   return undefined;

--- a/packages/mcp-provider-code-analyzer/src/tools/query_code_analyzer_results.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/query_code_analyzer_results.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { z } from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { McpTool, McpToolConfig, ReleaseState, Toolset, TelemetryService, TelemetryEvent } from "@salesforce/mcp-provider-api";
-import { getErrorMessage } from "../utils.js";
+import { getErrorMessage, sanitizePath } from "../utils.js";
 import * as Constants from "../constants.js";
 import { QueryResultsAction, QueryResultsActionImpl, QueryResultsInput, QueryResultsOutput } from "../actions/query-results.js";
 import { validateSelectorForQuery, parseSelectorToFilters } from "../selector.js";
@@ -190,8 +190,8 @@ function emitQueryTelemetry(telemetryService: TelemetryService | undefined, data
 }
 
 function validateInput(input: z.infer<typeof inputSchema>): void {
-    if (!path.isAbsolute(input.resultsFile)) {
-        throw new Error(`resultsFile must be an absolute path: ${input.resultsFile}`);
+    if (!sanitizePath(input.resultsFile)) {
+        throw new Error(`Invalid results file path: ${input.resultsFile}. Path must be absolute and not contain traversal sequences.`);
     }
     // Existence will be validated by the action while reading
 }

--- a/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
@@ -33,6 +33,11 @@ export const inputSchema = z.object({
     selector: z.string().optional().describe(
         `Optional selector for Code Analyzer rules (same semantics as "list_code_analyzer_rules"). If omitted, "recommended" rules run.\n` +
         `Examples: "Security:pmd", "Critical", "(Security,Performance):eslint", "pmd:High"`
+    ),
+    configPath: z.string().optional().describe(
+        `Optional absolute path to a Code Analyzer configuration file (code-analyzer.yml or code-analyzer.yaml). ` +
+        `If omitted, the tool will search for a config file in the current working directory. ` +
+        `If no config is found, default configuration will be used.`
     )
 });
 type InputArgsShape = typeof inputSchema.shape;

--- a/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
@@ -36,8 +36,7 @@ export const inputSchema = z.object({
     ),
     configPath: z.string().optional().describe(
         `Optional absolute path to a Code Analyzer configuration file (code-analyzer.yml or code-analyzer.yaml). ` +
-        `If omitted, the tool will search for a config file in the current working directory. ` +
-        `If no config is found, default configuration will be used.`
+        `If omitted, the tool will use default configuration and ignore any code-analyzer yaml files in the working directory.`
     )
 });
 type InputArgsShape = typeof inputSchema.shape;

--- a/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
@@ -5,7 +5,6 @@ import { McpTool, McpToolConfig, ReleaseState, Services, Toolset } from "@salesf
 import { getMessage } from "../messages.js";
 import { getErrorMessage } from "../utils.js";
 import { RunAnalyzerAction, RunAnalyzerActionImpl, RunInput, RunOutput } from "../actions/run-analyzer.js";
-import { CodeAnalyzerListRulesMcpTool } from "./list_code_analyzer_rules.js";
 import { CodeAnalyzerConfigFactoryImpl } from "../factories/CodeAnalyzerConfigFactory.js";
 import { EnginePluginsFactoryImpl } from "../factories/EnginePluginsFactory.js";
 
@@ -30,8 +29,15 @@ OPTIONAL - Custom Config Path:
 - Use "configPath" parameter only if the config file has a custom name or is in a non-standard location.
 - If provided, configPath takes precedence over config files in workingDirectory.
 
-Optional: Provide a "selector" (same semantics as "list_code_analyzer_rules") to choose which rules to run.
+Optional: Provide a "selector" to choose which rules to run. Supports:
+- Rule names: "WhileLoopsMustUseBraces", "no-unused-vars"
+- Engines: "pmd", "eslint", "regex"
+- Tags: "Security", "Performance", "Recommended"
+- Severities: "Critical", "High", "1", "2"
+- Combinations: "Security:pmd", "(Security,Performance):eslint"
+
 Examples:
+- "WhileLoopsMustUseBraces" → run specific rule by name
 - "Security:pmd" → run Security-tagged PMD rules
 - "Critical" → run all Critical-severity rules
 - "(Security,Performance):eslint" → ESLint rules tagged Security or Performance
@@ -46,8 +52,8 @@ export const inputSchema = z.object({
         `This should typically be the root directory of the project being analyzed.`
     ),
     selector: z.string().optional().describe(
-        `Optional selector for Code Analyzer rules (same semantics as "list_code_analyzer_rules"). If omitted, "recommended" rules run.\n` +
-        `Examples: "Security:pmd", "Critical", "(Security,Performance):eslint", "pmd:High"`
+        `Optional selector for Code Analyzer rules. Supports rule names, engines, tags, severities, and combinations. If omitted, "recommended" rules run.\n` +
+        `Examples: "WhileLoopsMustUseBraces", "Security:pmd", "Critical", "(Security,Performance):eslint", "pmd:High"`
     ),
     configPath: z.string().optional().describe(
         `Optional absolute path to a Code Analyzer configuration file with a custom name or in a non-standard location. ` +
@@ -115,11 +121,6 @@ export class CodeAnalyzerRunMcpTool extends McpTool<InputArgsShape, OutputArgsSh
         try {
             validateInput(input);
 
-            const selectorValidationError: CallToolResult | null = validateSelectorIfProvided(input.selector);
-            if (selectorValidationError) {
-                return selectorValidationError;
-            }
-
             const unsupportedEngineError: CallToolResult | null = rejectUnsupportedEnginesIfPresent(input.selector);
             if (unsupportedEngineError) {
                 return unsupportedEngineError;
@@ -144,18 +145,6 @@ function selectorIncludesEngine(selectorLower: string, engineLower: 'sfge' | 'fl
     // Match token boundaries: start or one of "(:," before, and end or one of ":),"
     const pattern = new RegExp(`(^|[(:,])\\s*${engineLower}\\s*(?=[:),]|$)`, 'i');
     return pattern.test(selectorLower);
-}
-
-function validateSelectorIfProvided(selector: string | undefined): CallToolResult | null {
-    if (!selector || selector.trim().length === 0) {
-        return null;
-    }
-    const validation = CodeAnalyzerListRulesMcpTool.validateSelector(selector);
-    if (validation.valid === false) {
-        const msg = `Invalid selector token(s): ${validation.invalidTokens.join(', ')}`;
-        return makeErrorResult(msg);
-    }
-    return null;
 }
 
 function rejectUnsupportedEnginesIfPresent(selector: string | undefined): CallToolResult | null {

--- a/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
@@ -20,6 +20,12 @@ When to use this tool:
 - When the user asks you to generate files, use this tool to scan those files.
 - When the user asks you to check code for problems, use this tool to do that.
 
+IMPORTANT - Configuration File Discovery:
+- BEFORE running this tool, search for code-analyzer.yml or code-analyzer.yaml in the workspace root directory (the parent directory of the target files).
+- If a config file exists, pass its absolute path via the "configPath" parameter.
+- Config files contain custom rule configurations, severities, and ignore patterns that must be respected.
+- If no config file is found, the tool will use default configuration.
+
 Optional: Provide a "selector" (same semantics as "list_code_analyzer_rules") to choose which rules to run.
 Examples:
 - "Security:pmd" → run Security-tagged PMD rules
@@ -36,7 +42,9 @@ export const inputSchema = z.object({
     ),
     configPath: z.string().optional().describe(
         `Optional absolute path to a Code Analyzer configuration file (code-analyzer.yml or code-analyzer.yaml). ` +
-        `If omitted, the tool will use default configuration and ignore any code-analyzer yaml files in the working directory.`
+        `IMPORTANT: Search for this file in the workspace root directory before running the tool. ` +
+        `If a config file exists, provide its absolute path here to respect custom rule configurations. ` +
+        `If omitted, the tool will use default configuration.`
     )
 });
 type InputArgsShape = typeof inputSchema.shape;

--- a/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
@@ -20,11 +20,15 @@ When to use this tool:
 - When the user asks you to generate files, use this tool to scan those files.
 - When the user asks you to check code for problems, use this tool to do that.
 
-IMPORTANT - Configuration File Discovery:
-- BEFORE running this tool, search for code-analyzer.yml or code-analyzer.yaml in the workspace root directory (the parent directory of the target files).
-- If a config file exists, pass its absolute path via the "configPath" parameter.
-- Config files contain custom rule configurations, severities, and ignore patterns that must be respected.
-- If no config file is found, the tool will use default configuration.
+REQUIRED INPUT - Working Directory:
+- You MUST provide the "workingDirectory" parameter with the absolute path to the project/workspace root.
+- The tool will automatically search for code-analyzer.yml or code-analyzer.yaml config files in this directory.
+- Config files contain custom rule configurations, severities, and ignore patterns that will be respected.
+- If no config file is found in the working directory, default configuration will be used.
+
+OPTIONAL - Custom Config Path:
+- Use "configPath" parameter only if the config file has a custom name or is in a non-standard location.
+- If provided, configPath takes precedence over config files in workingDirectory.
 
 Optional: Provide a "selector" (same semantics as "list_code_analyzer_rules") to choose which rules to run.
 Examples:
@@ -36,15 +40,19 @@ After completion: Use the "query_code_analyzer_results" tool to filter and expla
 
 export const inputSchema = z.object({
     target: z.array(z.string()).describe(`A JSON-formatted array of between 1 and ${MAX_ALLOWABLE_TARGET_COUNT} files on the users machine that should be scanned. These paths MUST be ABSOLUTE paths, and not relative paths.`),
+    workingDirectory: z.string().describe(
+        `REQUIRED: Absolute path to the workspace/working directory. ` +
+        `The tool will automatically search for code-analyzer.yml or code-analyzer.yaml config files in this directory. ` +
+        `This should typically be the root directory of the project being analyzed.`
+    ),
     selector: z.string().optional().describe(
         `Optional selector for Code Analyzer rules (same semantics as "list_code_analyzer_rules"). If omitted, "recommended" rules run.\n` +
         `Examples: "Security:pmd", "Critical", "(Security,Performance):eslint", "pmd:High"`
     ),
     configPath: z.string().optional().describe(
-        `Optional absolute path to a Code Analyzer configuration file (code-analyzer.yml or code-analyzer.yaml). ` +
-        `IMPORTANT: Search for this file in the workspace root directory before running the tool. ` +
-        `If a config file exists, provide its absolute path here to respect custom rule configurations. ` +
-        `If omitted, the tool will use default configuration.`
+        `Optional absolute path to a Code Analyzer configuration file with a custom name or in a non-standard location. ` +
+        `Use this when your config file has a different name or is not in the working directory. ` +
+        `If provided, this takes precedence over config files found in workingDirectory.`
     )
 });
 type InputArgsShape = typeof inputSchema.shape;

--- a/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/run_code_analyzer.ts
@@ -3,7 +3,7 @@ import { z }  from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { McpTool, McpToolConfig, ReleaseState, Services, Toolset } from "@salesforce/mcp-provider-api";
 import { getMessage } from "../messages.js";
-import { getErrorMessage } from "../utils.js";
+import { getErrorMessage, sanitizePath } from "../utils.js";
 import { RunAnalyzerAction, RunAnalyzerActionImpl, RunInput, RunOutput } from "../actions/run-analyzer.js";
 import { CodeAnalyzerConfigFactoryImpl } from "../factories/CodeAnalyzerConfigFactory.js";
 import { EnginePluginsFactoryImpl } from "../factories/EnginePluginsFactory.js";
@@ -19,15 +19,15 @@ When to use this tool:
 - When the user asks you to generate files, use this tool to scan those files.
 - When the user asks you to check code for problems, use this tool to do that.
 
-REQUIRED INPUT - Working Directory:
-- You MUST provide the "workingDirectory" parameter with the absolute path to the project/workspace root.
+REQUIRED INPUT - Directory:
+- You MUST provide the "directory" parameter with the absolute path to the project/workspace root.
 - The tool will automatically search for code-analyzer.yml or code-analyzer.yaml config files in this directory.
 - Config files contain custom rule configurations, severities, and ignore patterns that will be respected.
-- If no config file is found in the working directory, default configuration will be used.
+- If no config file is found in the directory, default configuration will be used.
 
 OPTIONAL - Custom Config Path:
 - Use "configPath" parameter only if the config file has a custom name or is in a non-standard location.
-- If provided, configPath takes precedence over config files in workingDirectory.
+- If provided, configPath takes precedence over config files in directory.
 
 Optional: Provide a "selector" to choose which rules to run. Supports:
 - Rule names: "WhileLoopsMustUseBraces", "no-unused-vars"
@@ -46,8 +46,8 @@ After completion: Use the "query_code_analyzer_results" tool to filter and expla
 
 export const inputSchema = z.object({
     target: z.array(z.string()).describe(`A JSON-formatted array of between 1 and ${MAX_ALLOWABLE_TARGET_COUNT} files on the users machine that should be scanned. These paths MUST be ABSOLUTE paths, and not relative paths.`),
-    workingDirectory: z.string().describe(
-        `REQUIRED: Absolute path to the workspace/working directory. ` +
+    directory: z.string().describe(
+        `REQUIRED: Absolute path to the workspace/directory. ` +
         `The tool will automatically search for code-analyzer.yml or code-analyzer.yaml config files in this directory. ` +
         `This should typically be the root directory of the project being analyzed.`
     ),
@@ -57,8 +57,8 @@ export const inputSchema = z.object({
     ),
     configPath: z.string().optional().describe(
         `Optional absolute path to a Code Analyzer configuration file with a custom name or in a non-standard location. ` +
-        `Use this when your config file has a different name or is not in the working directory. ` +
-        `If provided, this takes precedence over config files found in workingDirectory.`
+        `Use this when your config file has a different name or is not in the directory. ` +
+        `If provided, this takes precedence over config files found in directory.`
     )
 });
 type InputArgsShape = typeof inputSchema.shape;
@@ -178,7 +178,22 @@ function validateInput(input: RunInput): void {
     if (input.target.length > MAX_ALLOWABLE_TARGET_COUNT) {
         throw new Error(getMessage('tooManyTargets', input.target.length, MAX_ALLOWABLE_TARGET_COUNT));
     }
+
+    // Validate directory path
+    if (!sanitizePath(input.directory)) {
+        throw new Error(`Invalid directory path: ${input.directory}. Path must be absolute and not contain traversal sequences.`);
+    }
+
+    // Validate configPath if provided
+    if (input.configPath && !sanitizePath(input.configPath)) {
+        throw new Error(`Invalid config path: ${input.configPath}. Path must be absolute and not contain traversal sequences.`);
+    }
+
+    // Validate target paths
     for (const entry of input.target) {
+        if (!sanitizePath(entry)) {
+            throw new Error(`Invalid target path: ${entry}. Path must be absolute and not contain traversal sequences.`);
+        }
         if (!fs.existsSync(entry)) {
             throw new Error(getMessage('allTargetsMustExist', entry));
         }

--- a/packages/mcp-provider-code-analyzer/src/utils.ts
+++ b/packages/mcp-provider-code-analyzer/src/utils.ts
@@ -1,9 +1,44 @@
+import path from "node:path";
+
 // TODO: move this file into a `src/utils/` folder in a follow-up PR.
 /**
  * Helper function to easily get an error message from a catch statement
  */
 export function getErrorMessage(error: unknown): string {
     return error instanceof Error ? error.message : /* istanbul ignore next */ String(error);
+}
+
+/**
+ * Sanitize a user-provided path to prevent path traversal attacks.
+ * Returns true if the path is safe to use, false otherwise.
+ *
+ * Based on dx-core's sanitization approach:
+ * - Decodes URL-encoded sequences
+ * - Normalizes Unicode characters
+ * - Checks for path traversal patterns (.., Unicode ellipsis)
+ * - Verifies the path is absolute
+ * - Handles Windows drive-relative paths
+ */
+export function sanitizePath(userPath: string): boolean {
+    // Decode URL-encoded sequences
+    const decodedPath = decodeURIComponent(userPath);
+    // Normalize Unicode characters
+    const normalizedPath = decodedPath.normalize();
+
+    // Check for various traversal patterns
+    const hasTraversal =
+        normalizedPath.includes('..') ||
+        normalizedPath.includes('\u2025') || // Unicode horizontal ellipsis
+        normalizedPath.includes('\u2026'); // Unicode vertical ellipsis
+
+    // `path.isAbsolute` doesn't cover Windows's drive-relative path:
+    // https://github.com/nodejs/node/issues/56766
+    //
+    // we can assume it's a drive-relative path if it starts with `\`.
+    const isAbsolute =
+        path.isAbsolute(userPath) && (process.platform === 'win32' ? !userPath.startsWith('\\') : true);
+
+    return !hasTraversal && isAbsolute;
 }
 
 /**

--- a/packages/mcp-provider-code-analyzer/test/actions/describe-rule.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/actions/describe-rule.test.ts
@@ -23,26 +23,27 @@ const __dirname = path.dirname(__filename);
 describe('DescribeRuleActionImpl', () => {
     describe.each([
         {
-            case: 'When a custom configuration is present in the run directory',
-            pathToDirectory: path.resolve(__dirname, '..', 'fixtures', 'sample-workspaces', 'workspace-with-config'),
+            case: 'When a custom configuration is explicitly provided',
+            configFactory: new CustomizableConfigFactory(JSON.stringify({
+                rules: {
+                    pmd: {
+                        WhileLoopsMustUseBraces: {
+                            severity: 1,
+                            tags: ['Recommended', 'Apex', 'MyCustomTag']
+                        }
+                    }
+                }
+            })),
             expectedSeverity: 1,
             expectedTags: ['Recommended', 'Apex', 'MyCustomTag']
         },
         {
-            case: 'When no custom configuration is present',
-            pathToDirectory: path.resolve(__dirname, '..', 'fixtures', 'sample-workspaces', 'workspace-without-config'),
+            case: 'When no custom configuration is provided (uses defaults)',
+            configFactory: new CodeAnalyzerConfigFactoryImpl(),
             expectedSeverity: 3,
             expectedTags: ['Recommended', 'CodeStyle', 'Apex']
         }
-    ])('$case', ({pathToDirectory, expectedSeverity, expectedTags}) => {
-
-        beforeEach(() => {
-            process.chdir(pathToDirectory);
-        });
-
-        afterEach(() => {
-            process.chdir(__dirname);
-        });
+    ])('$case', ({configFactory, expectedSeverity, expectedTags}) => {
 
         it('When asked to describe an existing rule, the correct description is returned', async () => {
             const input: DescribeRuleInput = {
@@ -51,7 +52,7 @@ describe('DescribeRuleActionImpl', () => {
             };
 
             const action: DescribeRuleActionImpl = new DescribeRuleActionImpl({
-                configFactory: new CodeAnalyzerConfigFactoryImpl(),
+                configFactory,
                 enginePluginsFactory: new EnginePluginsFactoryImpl()
             });
 
@@ -70,7 +71,7 @@ describe('DescribeRuleActionImpl', () => {
             };
 
             const action: DescribeRuleActionImpl = new DescribeRuleActionImpl({
-                configFactory: new CodeAnalyzerConfigFactoryImpl(),
+                configFactory,
                 enginePluginsFactory: new EnginePluginsFactoryImpl()
             });
 

--- a/packages/mcp-provider-code-analyzer/test/actions/run-analyzer.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/actions/run-analyzer.test.ts
@@ -196,7 +196,8 @@ describe('RunAnalyzerActionImpl', () => {
         }
     ])('When $case, $expectation', async ({target, comparisonFile, configFactory, enginePluginsFactory, keyStatusPhrases, expectedSummary}) => {
         const input: RunInput = {
-            target
+            target,
+            workingDirectory: PATH_TO_SAMPLE_TARGETS
         }
 
         const action: RunAnalyzerActionImpl = new RunAnalyzerActionImpl({
@@ -240,7 +241,8 @@ describe('RunAnalyzerActionImpl', () => {
     describe('Telemetry Emission', () => {
         it('When a telemetry service is provided, it is used', async () => {
             const input: RunInput = {
-                target: [path.join(PATH_TO_SAMPLE_TARGETS, 'ApexTarget1.cls')]
+                target: [path.join(PATH_TO_SAMPLE_TARGETS, 'ApexTarget1.cls')],
+                workingDirectory: PATH_TO_SAMPLE_TARGETS
             };
 
             const spyTelemetryService: SpyTelemetryService = new SpyTelemetryService();

--- a/packages/mcp-provider-code-analyzer/test/actions/run-analyzer.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/actions/run-analyzer.test.ts
@@ -197,7 +197,7 @@ describe('RunAnalyzerActionImpl', () => {
     ])('When $case, $expectation', async ({target, comparisonFile, configFactory, enginePluginsFactory, keyStatusPhrases, expectedSummary}) => {
         const input: RunInput = {
             target,
-            workingDirectory: PATH_TO_SAMPLE_TARGETS
+            directory: PATH_TO_SAMPLE_TARGETS
         }
 
         const action: RunAnalyzerActionImpl = new RunAnalyzerActionImpl({
@@ -242,7 +242,7 @@ describe('RunAnalyzerActionImpl', () => {
         it('When a telemetry service is provided, it is used', async () => {
             const input: RunInput = {
                 target: [path.join(PATH_TO_SAMPLE_TARGETS, 'ApexTarget1.cls')],
-                workingDirectory: PATH_TO_SAMPLE_TARGETS
+                directory: PATH_TO_SAMPLE_TARGETS
             };
 
             const spyTelemetryService: SpyTelemetryService = new SpyTelemetryService();

--- a/packages/mcp-provider-code-analyzer/test/e2e/run_code_analyzer-e2e.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/e2e/run_code_analyzer-e2e.test.ts
@@ -6,6 +6,7 @@ import { inputSchema } from '../../src/tools/run_code_analyzer.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const PATH_TO_SAMPLE_TARGETS = path.join(__dirname, '..', 'fixtures', 'sample-targets');
 
 describe('run_code_analyzer', () => {
     const client = new McpTestClient({
@@ -50,7 +51,8 @@ describe('run_code_analyzer', () => {
         const result = await client.callTool(testInputSchema, {
             name: 'run_code_analyzer',
             params: {
-                target: [target]
+                target: [target],
+                workingDirectory: PATH_TO_SAMPLE_TARGETS
             }
         }, 60000);
 
@@ -62,7 +64,8 @@ describe('run_code_analyzer', () => {
         const result = await client.callTool(testInputSchema, {
             name: 'run_code_analyzer',
             params: {
-                target: [path.join(__dirname, '..', 'fixtures', 'sample-targets', 'NoTargetWithThisName.cls')]
+                target: [path.join(__dirname, '..', 'fixtures', 'sample-targets', 'NoTargetWithThisName.cls')],
+                workingDirectory: PATH_TO_SAMPLE_TARGETS
             }
         }, 60000);
 

--- a/packages/mcp-provider-code-analyzer/test/e2e/run_code_analyzer-e2e.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/e2e/run_code_analyzer-e2e.test.ts
@@ -52,7 +52,7 @@ describe('run_code_analyzer', () => {
             name: 'run_code_analyzer',
             params: {
                 target: [target],
-                workingDirectory: PATH_TO_SAMPLE_TARGETS
+                directory: PATH_TO_SAMPLE_TARGETS
             }
         }, 60000);
 
@@ -65,7 +65,7 @@ describe('run_code_analyzer', () => {
             name: 'run_code_analyzer',
             params: {
                 target: [path.join(__dirname, '..', 'fixtures', 'sample-targets', 'NoTargetWithThisName.cls')],
-                workingDirectory: PATH_TO_SAMPLE_TARGETS
+                directory: PATH_TO_SAMPLE_TARGETS
             }
         }, 60000);
 

--- a/packages/mcp-provider-code-analyzer/test/factories/CodeAnalyzerConfigFactory.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/factories/CodeAnalyzerConfigFactory.test.ts
@@ -1,0 +1,49 @@
+import path from "node:path";
+import { fileURLToPath } from "url";
+import { CodeAnalyzerConfigFactoryImpl } from "../../src/factories/CodeAnalyzerConfigFactory.js";
+import { CodeAnalyzerConfig } from "@salesforce/code-analyzer-core";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PATH_TO_WORKSPACE_WITH_CONFIG = path.resolve(__dirname, '..', 'fixtures', 'sample-workspaces', 'workspace-with-config');
+const PATH_TO_CONFIG_FILE = path.join(PATH_TO_WORKSPACE_WITH_CONFIG, 'code-analyzer.yml');
+
+describe("CodeAnalyzerConfigFactoryImpl", () => {
+    let factory: CodeAnalyzerConfigFactoryImpl;
+
+    beforeEach(() => {
+        factory = new CodeAnalyzerConfigFactoryImpl();
+    });
+
+    describe("create with no configPath", () => {
+        it("When no config file exists in current directory, then returns default config", () => {
+            const config: CodeAnalyzerConfig = factory.create();
+            expect(config).toBeDefined();
+            expect(config.getLogFolder()).toBeDefined();
+        });
+    });
+
+    describe("create with configPath", () => {
+        it("When valid config path is provided, then loads config from that path", () => {
+            const config: CodeAnalyzerConfig = factory.create(PATH_TO_CONFIG_FILE);
+            expect(config).toBeDefined();
+
+            // Verify the config was loaded from the specified file
+            // The test config file has a custom rule override with severity 1
+            const ruleOverride = config.getRuleOverrideFor('pmd', 'WhileLoopsMustUseBraces');
+            expect(ruleOverride.severity).toBe(1);
+            expect(ruleOverride.tags).toContain('MyCustomTag');
+        });
+
+        it("When config path does not exist, then throws error", () => {
+            const nonExistentPath = path.join(__dirname, 'does-not-exist.yml');
+            expect(() => factory.create(nonExistentPath)).toThrow('Specified config file does not exist');
+        });
+
+        it("When config path is relative, then throws error", () => {
+            const relativePath = './code-analyzer.yml';
+            expect(() => factory.create(relativePath)).toThrow('Config path must be an absolute path');
+        });
+    });
+});

--- a/packages/mcp-provider-code-analyzer/test/factories/CodeAnalyzerConfigFactory.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/factories/CodeAnalyzerConfigFactory.test.ts
@@ -7,6 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const PATH_TO_WORKSPACE_WITH_CONFIG = path.resolve(__dirname, '..', 'fixtures', 'sample-workspaces', 'workspace-with-config');
+const PATH_TO_WORKSPACE_WITHOUT_CONFIG = path.resolve(__dirname, '..', 'fixtures', 'sample-workspaces', 'workspace-without-config');
 const PATH_TO_CONFIG_FILE = path.join(PATH_TO_WORKSPACE_WITH_CONFIG, 'code-analyzer.yml');
 
 describe("CodeAnalyzerConfigFactoryImpl", () => {
@@ -16,11 +17,47 @@ describe("CodeAnalyzerConfigFactoryImpl", () => {
         factory = new CodeAnalyzerConfigFactoryImpl();
     });
 
-    describe("create with no configPath", () => {
-        it("When no config file exists in current directory, then returns default config", () => {
+    describe("create with no parameters", () => {
+        it("When no parameters provided, then returns default config", () => {
             const config: CodeAnalyzerConfig = factory.create();
             expect(config).toBeDefined();
             expect(config.getLogFolder()).toBeDefined();
+        });
+    });
+
+    describe("create with workingDirectory", () => {
+        it("When workingDirectory contains config file, then loads config from that directory", () => {
+            const config: CodeAnalyzerConfig = factory.create(undefined, PATH_TO_WORKSPACE_WITH_CONFIG);
+            expect(config).toBeDefined();
+
+            // Verify the config was loaded from the working directory
+            // The test config file has a custom rule override with severity 1
+            const ruleOverride = config.getRuleOverrideFor('pmd', 'WhileLoopsMustUseBraces');
+            expect(ruleOverride.severity).toBe(1);
+            expect(ruleOverride.tags).toContain('MyCustomTag');
+        });
+
+        it("When workingDirectory does not contain config file, then returns default config", () => {
+            const config: CodeAnalyzerConfig = factory.create(undefined, PATH_TO_WORKSPACE_WITHOUT_CONFIG);
+            expect(config).toBeDefined();
+
+            // Should use default config (severity 3 for this rule)
+            const ruleOverride = config.getRuleOverrideFor('pmd', 'WhileLoopsMustUseBraces');
+            expect(ruleOverride.severity).toBeUndefined(); // No override in default config
+        });
+
+        it("When workingDirectory does not exist, then throws error", () => {
+            const nonExistentPath = path.join(__dirname, 'does-not-exist');
+            expect(() => factory.create(undefined, nonExistentPath)).toThrow('Working directory does not exist');
+        });
+
+        it("When workingDirectory is a file not a directory, then throws error", () => {
+            expect(() => factory.create(undefined, PATH_TO_CONFIG_FILE)).toThrow('Working directory must be a directory');
+        });
+
+        it("When workingDirectory is relative, then throws error", () => {
+            const relativePath = './some-dir';
+            expect(() => factory.create(undefined, relativePath)).toThrow('Working directory must be an absolute path');
         });
     });
 
@@ -44,6 +81,16 @@ describe("CodeAnalyzerConfigFactoryImpl", () => {
         it("When config path is relative, then throws error", () => {
             const relativePath = './code-analyzer.yml';
             expect(() => factory.create(relativePath)).toThrow('Config path must be an absolute path');
+        });
+
+        it("When both configPath and workingDirectory provided, configPath takes precedence", () => {
+            const config: CodeAnalyzerConfig = factory.create(PATH_TO_CONFIG_FILE, PATH_TO_WORKSPACE_WITHOUT_CONFIG);
+            expect(config).toBeDefined();
+
+            // Should load from configPath (which has custom severity 1), not workingDirectory
+            const ruleOverride = config.getRuleOverrideFor('pmd', 'WhileLoopsMustUseBraces');
+            expect(ruleOverride.severity).toBe(1);
+            expect(ruleOverride.tags).toContain('MyCustomTag');
         });
     });
 });

--- a/packages/mcp-provider-code-analyzer/test/factories/CodeAnalyzerConfigFactory.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/factories/CodeAnalyzerConfigFactory.test.ts
@@ -25,19 +25,19 @@ describe("CodeAnalyzerConfigFactoryImpl", () => {
         });
     });
 
-    describe("create with workingDirectory", () => {
-        it("When workingDirectory contains config file, then loads config from that directory", () => {
+    describe("create with directory", () => {
+        it("When directory contains config file, then loads config from that directory", () => {
             const config: CodeAnalyzerConfig = factory.create(undefined, PATH_TO_WORKSPACE_WITH_CONFIG);
             expect(config).toBeDefined();
 
-            // Verify the config was loaded from the working directory
+            // Verify the config was loaded from the directory
             // The test config file has a custom rule override with severity 1
             const ruleOverride = config.getRuleOverrideFor('pmd', 'WhileLoopsMustUseBraces');
             expect(ruleOverride.severity).toBe(1);
             expect(ruleOverride.tags).toContain('MyCustomTag');
         });
 
-        it("When workingDirectory does not contain config file, then returns default config", () => {
+        it("When directory does not contain config file, then returns default config", () => {
             const config: CodeAnalyzerConfig = factory.create(undefined, PATH_TO_WORKSPACE_WITHOUT_CONFIG);
             expect(config).toBeDefined();
 
@@ -46,18 +46,18 @@ describe("CodeAnalyzerConfigFactoryImpl", () => {
             expect(ruleOverride.severity).toBeUndefined(); // No override in default config
         });
 
-        it("When workingDirectory does not exist, then throws error", () => {
+        it("When directory does not exist, then throws error", () => {
             const nonExistentPath = path.join(__dirname, 'does-not-exist');
-            expect(() => factory.create(undefined, nonExistentPath)).toThrow('Working directory does not exist');
+            expect(() => factory.create(undefined, nonExistentPath)).toThrow('Directory does not exist');
         });
 
-        it("When workingDirectory is a file not a directory, then throws error", () => {
-            expect(() => factory.create(undefined, PATH_TO_CONFIG_FILE)).toThrow('Working directory must be a directory');
+        it("When directory is a file not a directory, then throws error", () => {
+            expect(() => factory.create(undefined, PATH_TO_CONFIG_FILE)).toThrow('Directory must be a directory');
         });
 
-        it("When workingDirectory is relative, then throws error", () => {
+        it("When directory is relative, then throws error", () => {
             const relativePath = './some-dir';
-            expect(() => factory.create(undefined, relativePath)).toThrow('Working directory must be an absolute path');
+            expect(() => factory.create(undefined, relativePath)).toThrow('Invalid directory path');
         });
     });
 
@@ -80,14 +80,14 @@ describe("CodeAnalyzerConfigFactoryImpl", () => {
 
         it("When config path is relative, then throws error", () => {
             const relativePath = './code-analyzer.yml';
-            expect(() => factory.create(relativePath)).toThrow('Config path must be an absolute path');
+            expect(() => factory.create(relativePath)).toThrow('Invalid config path');
         });
 
-        it("When both configPath and workingDirectory provided, configPath takes precedence", () => {
+        it("When both configPath and directory provided, configPath takes precedence", () => {
             const config: CodeAnalyzerConfig = factory.create(PATH_TO_CONFIG_FILE, PATH_TO_WORKSPACE_WITHOUT_CONFIG);
             expect(config).toBeDefined();
 
-            // Should load from configPath (which has custom severity 1), not workingDirectory
+            // Should load from configPath (which has custom severity 1), not directory
             const ruleOverride = config.getRuleOverrideFor('pmd', 'WhileLoopsMustUseBraces');
             expect(ruleOverride.severity).toBe(1);
             expect(ruleOverride.tags).toContain('MyCustomTag');

--- a/packages/mcp-provider-code-analyzer/test/stubs/CustomizableConfigFactory.ts
+++ b/packages/mcp-provider-code-analyzer/test/stubs/CustomizableConfigFactory.ts
@@ -8,7 +8,7 @@ export class CustomizableConfigFactory implements CodeAnalyzerConfigFactory {
         this.configString = configString;
     }
 
-    public create(): CodeAnalyzerConfig {
+    public create(_configPath?: string): CodeAnalyzerConfig {
         return CodeAnalyzerConfig.fromJsonString(this.configString);
     }
 }

--- a/packages/mcp-provider-code-analyzer/test/stubs/CustomizableConfigFactory.ts
+++ b/packages/mcp-provider-code-analyzer/test/stubs/CustomizableConfigFactory.ts
@@ -8,7 +8,7 @@ export class CustomizableConfigFactory implements CodeAnalyzerConfigFactory {
         this.configString = configString;
     }
 
-    public create(_configPath?: string): CodeAnalyzerConfig {
+    public create(_configPath?: string, _workingDirectory?: string): CodeAnalyzerConfig {
         return CodeAnalyzerConfig.fromJsonString(this.configString);
     }
 }

--- a/packages/mcp-provider-code-analyzer/test/stubs/CustomizableConfigFactory.ts
+++ b/packages/mcp-provider-code-analyzer/test/stubs/CustomizableConfigFactory.ts
@@ -8,7 +8,7 @@ export class CustomizableConfigFactory implements CodeAnalyzerConfigFactory {
         this.configString = configString;
     }
 
-    public create(_configPath?: string, _workingDirectory?: string): CodeAnalyzerConfig {
+    public create(_configPath?: string, _directory?: string): CodeAnalyzerConfig {
         return CodeAnalyzerConfig.fromJsonString(this.configString);
     }
 }

--- a/packages/mcp-provider-code-analyzer/test/tools/query_code_analyzer_results.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/tools/query_code_analyzer_results.test.ts
@@ -158,7 +158,7 @@ describe("CodeAnalyzerQueryResultsMcpTool", () => {
 
     const res = await tool.exec({ resultsFile: relPath, selector: "Security", topN: 5 });
     expect(res.isError).toBe(true);
-    expect(res.structuredContent?.status).toContain("resultsFile must be an absolute path");
+    expect(res.structuredContent?.status).toContain("Invalid results file path");
   });
 
   it("wraps action output into content and structuredContent", async () => {

--- a/packages/mcp-provider-code-analyzer/test/tools/run_code_analyzer.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/tools/run_code_analyzer.test.ts
@@ -34,7 +34,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
         expect(config.title).toEqual('Run Code Analyzer');
         expect(config.description).toContain('A tool for performing static analysis against code.');
         expect(config.inputSchema).toBeTypeOf('object');
-        expect(Object.keys(config.inputSchema as object).sort()).toEqual(['configPath', 'selector', 'target']);
+        expect(Object.keys(config.inputSchema as object).sort()).toEqual(['configPath', 'selector', 'target', 'workingDirectory']);
         expect(config.outputSchema).toBeTypeOf('object');
         expect(Object.keys(config.outputSchema as object)).toEqual(['status', 'resultsFile', 'summary']);
         expect(config.annotations).toEqual({readOnlyHint: false});
@@ -61,10 +61,14 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
             const spyAction: SpyRunAction = new SpyRunAction();
             tool = new CodeAnalyzerRunMcpTool(spyAction);
 
-            const result: CallToolResult = await tool.exec({target: sampleTargets.slice(0, 5)});
+            const result: CallToolResult = await tool.exec({
+                target: sampleTargets.slice(0, 5),
+                workingDirectory: PATH_TO_SAMPLE_TARGETS
+            });
 
             expect(spyAction.execCallHistory).toHaveLength(1);
             expect(spyAction.execCallHistory[0].target).toEqual(sampleTargets.slice(0, 5));
+            expect(spyAction.execCallHistory[0].workingDirectory).toEqual(PATH_TO_SAMPLE_TARGETS);
 
             const expectedOutput: RunOutput = {
                 status: "Spy successfully invoked"
@@ -79,28 +83,32 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
             {
                 case: 'paths to files that do not exist',
                 args: {
-                    target: [path.join(PATH_TO_SAMPLE_TARGETS, 'beep.cls')]
+                    target: [path.join(PATH_TO_SAMPLE_TARGETS, 'beep.cls')],
+                    workingDirectory: PATH_TO_SAMPLE_TARGETS
                 },
                 keyErrorPhrase: "must exist"
             },
             {
                 case: 'paths to directories',
                 args: {
-                    target: [PATH_TO_SAMPLE_TARGETS]
+                    target: [PATH_TO_SAMPLE_TARGETS],
+                    workingDirectory: PATH_TO_SAMPLE_TARGETS
                 },
                 keyErrorPhrase: "must be files"
             },
             {
                 case: 'lists in excess of 10 entries',
                 args: {
-                    target: sampleTargets
+                    target: sampleTargets,
+                    workingDirectory: PATH_TO_SAMPLE_TARGETS
                 },
                 keyErrorPhrase: "maximum allowable length of 10"
             },
             {
                 case: 'empty lists',
                 args: {
-                    target: []
+                    target: [],
+                    workingDirectory: PATH_TO_SAMPLE_TARGETS
                 },
                 keyErrorPhrase: "non-empty"
             }
@@ -118,7 +126,10 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
             const throwingAction: ThrowingRunAction = new ThrowingRunAction();
             tool = new CodeAnalyzerRunMcpTool(throwingAction);
 
-            const result: CallToolResult = await tool.exec({target: sampleTargets.slice(0, 5)});
+            const result: CallToolResult = await tool.exec({
+                target: sampleTargets.slice(0, 5),
+                workingDirectory: PATH_TO_SAMPLE_TARGETS
+            });
 
             const expectedOutput: RunOutput = {
                 status: "Error from ThrowingRunAction"
@@ -134,6 +145,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
             tool = new CodeAnalyzerRunMcpTool(spyAction);
             const result: CallToolResult = await tool.exec({
                 target: [path.join(PATH_TO_SAMPLE_TARGETS, 'ApexTarget1.cls')],
+                workingDirectory: PATH_TO_SAMPLE_TARGETS,
                 selector: 'NotATag:9999'
             } as RunInput);
             expect(result.isError).toBe(true);
@@ -152,6 +164,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
             tool = new CodeAnalyzerRunMcpTool(spyAction);
             const result: CallToolResult = await tool.exec({
                 target: [path.join(PATH_TO_SAMPLE_TARGETS, 'ApexTarget1.cls'), path.join(PATH_TO_SAMPLE_TARGETS, 'ApexTarget2.cls')],
+                workingDirectory: PATH_TO_SAMPLE_TARGETS,
                 selector
             } as RunInput);
             expect(result.isError).toBe(true);

--- a/packages/mcp-provider-code-analyzer/test/tools/run_code_analyzer.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/tools/run_code_analyzer.test.ts
@@ -34,7 +34,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
         expect(config.title).toEqual('Run Code Analyzer');
         expect(config.description).toContain('A tool for performing static analysis against code.');
         expect(config.inputSchema).toBeTypeOf('object');
-        expect(Object.keys(config.inputSchema as object).sort()).toEqual(['configPath', 'selector', 'target', 'workingDirectory']);
+        expect(Object.keys(config.inputSchema as object).sort()).toEqual(['configPath', 'directory', 'selector', 'target']);
         expect(config.outputSchema).toBeTypeOf('object');
         expect(Object.keys(config.outputSchema as object)).toEqual(['status', 'resultsFile', 'summary']);
         expect(config.annotations).toEqual({readOnlyHint: false});
@@ -63,12 +63,12 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
 
             const result: CallToolResult = await tool.exec({
                 target: sampleTargets.slice(0, 5),
-                workingDirectory: PATH_TO_SAMPLE_TARGETS
+                directory: PATH_TO_SAMPLE_TARGETS
             });
 
             expect(spyAction.execCallHistory).toHaveLength(1);
             expect(spyAction.execCallHistory[0].target).toEqual(sampleTargets.slice(0, 5));
-            expect(spyAction.execCallHistory[0].workingDirectory).toEqual(PATH_TO_SAMPLE_TARGETS);
+            expect(spyAction.execCallHistory[0].directory).toEqual(PATH_TO_SAMPLE_TARGETS);
 
             const expectedOutput: RunOutput = {
                 status: "Spy successfully invoked"
@@ -84,7 +84,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
                 case: 'paths to files that do not exist',
                 args: {
                     target: [path.join(PATH_TO_SAMPLE_TARGETS, 'beep.cls')],
-                    workingDirectory: PATH_TO_SAMPLE_TARGETS
+                    directory: PATH_TO_SAMPLE_TARGETS
                 },
                 keyErrorPhrase: "must exist"
             },
@@ -92,7 +92,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
                 case: 'paths to directories',
                 args: {
                     target: [PATH_TO_SAMPLE_TARGETS],
-                    workingDirectory: PATH_TO_SAMPLE_TARGETS
+                    directory: PATH_TO_SAMPLE_TARGETS
                 },
                 keyErrorPhrase: "must be files"
             },
@@ -100,7 +100,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
                 case: 'lists in excess of 10 entries',
                 args: {
                     target: sampleTargets,
-                    workingDirectory: PATH_TO_SAMPLE_TARGETS
+                    directory: PATH_TO_SAMPLE_TARGETS
                 },
                 keyErrorPhrase: "maximum allowable length of 10"
             },
@@ -108,7 +108,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
                 case: 'empty lists',
                 args: {
                     target: [],
-                    workingDirectory: PATH_TO_SAMPLE_TARGETS
+                    directory: PATH_TO_SAMPLE_TARGETS
                 },
                 keyErrorPhrase: "non-empty"
             }
@@ -128,7 +128,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
 
             const result: CallToolResult = await tool.exec({
                 target: sampleTargets.slice(0, 5),
-                workingDirectory: PATH_TO_SAMPLE_TARGETS
+                directory: PATH_TO_SAMPLE_TARGETS
             });
 
             const expectedOutput: RunOutput = {
@@ -150,7 +150,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
             tool = new CodeAnalyzerRunMcpTool(spyAction);
             const result: CallToolResult = await tool.exec({
                 target: [path.join(PATH_TO_SAMPLE_TARGETS, 'ApexTarget1.cls'), path.join(PATH_TO_SAMPLE_TARGETS, 'ApexTarget2.cls')],
-                workingDirectory: PATH_TO_SAMPLE_TARGETS,
+                directory: PATH_TO_SAMPLE_TARGETS,
                 selector
             } as RunInput);
             expect(result.isError).toBe(true);
@@ -164,7 +164,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
             tool = new CodeAnalyzerRunMcpTool(spyAction);
             const result: CallToolResult = await tool.exec({
                 target: [path.join(PATH_TO_SAMPLE_TARGETS, 'ApexTarget1.cls')],
-                workingDirectory: PATH_TO_SAMPLE_TARGETS,
+                directory: PATH_TO_SAMPLE_TARGETS,
                 selector: 'WhileLoopsMustUseBraces:pmd'
             } as RunInput);
 

--- a/packages/mcp-provider-code-analyzer/test/tools/run_code_analyzer.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/tools/run_code_analyzer.test.ts
@@ -140,20 +140,6 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
             expect(result.structuredContent).toEqual(expectedOutput);
         });
 
-        it('When selector has invalid tokens, then return validation error (no action call)', async () => {
-            const spyAction: SpyRunAction = new SpyRunAction();
-            tool = new CodeAnalyzerRunMcpTool(spyAction);
-            const result: CallToolResult = await tool.exec({
-                target: [path.join(PATH_TO_SAMPLE_TARGETS, 'ApexTarget1.cls')],
-                workingDirectory: PATH_TO_SAMPLE_TARGETS,
-                selector: 'NotATag:9999'
-            } as RunInput);
-            expect(result.isError).toBe(true);
-            expect(result.structuredContent?.status).toContain('Invalid selector token(s):');
-            // Ensure action was not invoked
-            expect(spyAction.execCallHistory).toHaveLength(0);
-        });
-
         it.each([
             { selector: 'sfge:Security', engine: 'sfge' },
             { selector: 'flow:High', engine: 'flow' },
@@ -171,6 +157,20 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
             expect(result.structuredContent?.status).toContain('Unsupported engine(s) for this tool');
             // Ensure action was not invoked
             expect(spyAction.execCallHistory).toHaveLength(0);
+        });
+
+        it('When selector contains rule names, action is called with the selector', async () => {
+            const spyAction: SpyRunAction = new SpyRunAction();
+            tool = new CodeAnalyzerRunMcpTool(spyAction);
+            const result: CallToolResult = await tool.exec({
+                target: [path.join(PATH_TO_SAMPLE_TARGETS, 'ApexTarget1.cls')],
+                workingDirectory: PATH_TO_SAMPLE_TARGETS,
+                selector: 'WhileLoopsMustUseBraces:pmd'
+            } as RunInput);
+
+            expect(spyAction.execCallHistory).toHaveLength(1);
+            expect(spyAction.execCallHistory[0].selector).toEqual('WhileLoopsMustUseBraces:pmd');
+            expect(result.structuredContent?.status).toEqual('Spy successfully invoked');
         });
     });
 });

--- a/packages/mcp-provider-code-analyzer/test/tools/run_code_analyzer.test.ts
+++ b/packages/mcp-provider-code-analyzer/test/tools/run_code_analyzer.test.ts
@@ -34,7 +34,7 @@ describe("Tests for CodeAnalyzerRunMcpTool", () => {
         expect(config.title).toEqual('Run Code Analyzer');
         expect(config.description).toContain('A tool for performing static analysis against code.');
         expect(config.inputSchema).toBeTypeOf('object');
-        expect(Object.keys(config.inputSchema as object).sort()).toEqual(['selector', 'target']);
+        expect(Object.keys(config.inputSchema as object).sort()).toEqual(['configPath', 'selector', 'target']);
         expect(config.outputSchema).toBeTypeOf('object');
         expect(Object.keys(config.outputSchema as object)).toEqual(['status', 'resultsFile', 'summary']);
         expect(config.annotations).toEqual({readOnlyHint: false});


### PR DESCRIPTION
I have tested this in AFV and it is producing required results.

<img width="291" height="587" alt="image" src="https://github.com/user-attachments/assets/74b08694-2fef-4da3-b053-1d056489b900" />


 ## Summary
  @W-21974851@ - Adds `workingDirectory` parameter for automatic config discovery and fixes selector validation to support rule names.

  ## Changes

  ### 1. workingDirectory Parameter
  - Added mandatory `workingDirectory` parameter to `run_code_analyzer` tool
  - Automatically searches for `code-analyzer.yml/yaml` in the specified directory
  - `configPath` remains optional for custom config file names/locations
  - **Priority**: configPath → workingDirectory config discovery → defaults

  ### 2. Selector Rule Name Support
  - Removed strict token validation that rejected rule names
  - Now supports: `"WhileLoopsMustUseBraces"`, `"WhileLoopsMustUseBraces:pmd"`, etc.
  - Delegates validation to code-analyzer-core (validates syntax, accepts any tokens)

  ## Usage
  ```typescript
  // Standard case - auto-discovers config
  {
    target: ["/workspace/MyFile.cls"],
    workingDirectory: "/workspace"
  }

  // Rule name selector
  {
    target: ["/workspace/MyFile.cls"],
    workingDirectory: "/workspace",
    selector: "WhileLoopsMustUseBraces:pmd"