### PR TITLE
docs: fix typos, formatting, and broken links across docs and source

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -152,7 +152,7 @@ The server release workflow will automatically update to the latest provider ver
 - For server wiring details and how providers are loaded, see `packages/mcp/DEVELOPING.md`.
 
 ## Dependabot automation
-We have Dependabot enabled in this repo for the the packages listed in `.github/dependabot.yml`, if a PR passes all tests it will be automatically merged (cron job checks PRs opens every day).
+We have Dependabot enabled in this repo for the packages listed in `.github/dependabot.yml`. If a PR passes all tests, it will be automatically merged (cron job checks open PRs every day).
 This automation is opt-in by default (just add your package dir to the dependabot config), just note that you can't enable dependabot PRs and disable automerges yet (will be addressed in the future)
 
 ## Running the MCP server locally

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The `args` format shown in the preceding example is the same for all MCP clients
   - [Configure Toolsets](#configure-toolsets)
   - [Configure Tools](#configure-tools)
 - When writing the `args` option, surround both the flag names and their values in double quotes, and separate all flags and values with commas. Some flags are Boolean and don't take a value.
-- The preceding example shows three flags that take a string value (`--orgs`, `--toolsets`, and `--tools`) and one Boolean flag (`--allow-non-ga-tools`). This configuration starts a DX MCP Server that enables all the MCP tools in the `orgs`, `metadata`, `data`, and `users` toolsets and a specific tool called `run_apex_tests`. It also enables tools in these configured toolsets that aren't yet generally available.
+- The preceding example shows three flags that take a string value (`--orgs`, `--toolsets`, and `--tools`) and one Boolean flag (`--allow-non-ga-tools`). This configuration starts a DX MCP Server that enables all the MCP tools in the `orgs`, `metadata`, `data`, and `users` toolsets and a specific tool called `run_apex_test`. It also enables tools in these configured toolsets that aren't yet generally available.
 
 ## MCP Client Configurations
 
@@ -170,7 +170,7 @@ These are the available toolsets.
 | Toolset          | Description                                                                                                                                                                                                                                                                             | See Tool List                                         |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
 | `all`            | Enables all available tools from all toolsets. <br>We recommend that you configure only the toolsets you’re going to use, rather than all of them with this value. The DX MCP Server includes over 60 MCP tools, so enabling them all in your MCP client can overwhelm the LLM context. | N/A                                                   |
-| `aura-experts`   | Tools that provide Aura component analysis, blueprinting, and migration expertise..                                                                      | [Link](#aura-experts-toolset)                         |
+| `aura-experts`   | Tools that provide Aura component analysis, blueprinting, and migration expertise.                                                                      | [Link](#aura-experts-toolset)                         |
 | `code-analysis`  | Tools for static analysis of your code using Salesforce Code Analyzer.                                                                      | [Link](#code-analysis-toolset)                        |
 | `core`           | Core set of DX MCP tools. This toolset is always enabled.                                                               | [Link](#core-toolset-always-enabled)                  |
 | `data`           | Tools to manage the data in your org, such as listing all accounts.                                                     | [Link](#data-toolset)                                 |
@@ -208,7 +208,7 @@ For complete documentation, see [Use the Aura-to-LWC Migration Tools](https://de
 
 ### Code Analysis Toolset
 
-For complete documentation, see [Use MCP Tools to Analyze Your Code ](https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/guide/mcp.html) in the _Salesforce Code Analyzer Developer Guide_.
+For complete documentation, see [Use MCP Tools to Analyze Your Code](https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/guide/mcp.html) in the _Salesforce Code Analyzer Developer Guide_.
 
 - `create-custom-rule` (NON-GA) - Creates a custom XPath-based PMD rule from a provided Apex code sample.
 - `describe_code_analyzer_rule` (GA) - Gets the description of a Code Analyzer rule.
@@ -257,7 +257,7 @@ For complete documentation, see [Use DX MCP Tools for LWC](https://developer.sal
 
 #### Component Development 
 
-- `create_lwc_component_from_prd` (GA) - Creates complete LWC components from PRD specifications with proper structure. and best practices
+- `create_lwc_component_from_prd` (GA) - Creates complete LWC components from PRD specifications with proper structure and best practices.
 - `create_lwc_jest_tests` (GA) - Generates Jest test suites for LWC components with coverage and mocking.
 - `review_lwc_jest_tests` (GA) - Reviews and validates Jest test implementations for LWC components.
 
@@ -333,7 +333,7 @@ For complete documentation, see [Use the mobile Toolset](https://developer.sales
 - `create_mobile_lwc_geofencing` (GA) - Provides TypeScript API documentation for Salesforce LWC Geofencing Service, offering expert guidance for implementing geofencing features in LWC components.
 - `create_mobile_lwc_location` (GA) - Provides TypeScript API documentation for Salesforce LWC Location Service, offering expert guidance for implementing location services in LWC components.
 - `create_mobile_lwc_nfc` (GA) - Provides TypeScript API documentation for Salesforce LWC NFC Service, offering expert guidance for implementing NFC features in LWC components.
-- `create_mobile_lwc_payments` - Provides TypeScript API documentation for Salesforce LWC Payments Service, offering expert guidance for implementing payment processing features in LWC components.
+- `create_mobile_lwc_payments` (NON-GA) - Provides TypeScript API documentation for Salesforce LWC Payments Service, offering expert guidance for implementing payment processing features in LWC components.
 - `get_mobile_lwc_offline_analysis` (GA) - Analyzes LWC components for mobile-specific issues and provides detailed recommendations for mobile offline compatibility and performance improvements.
 - `get_mobile_lwc_offline_guidance` (GA) - Provides structured review instructions to detect and remediate mobile offline code violations in LWC components for Salesforce mobile apps.
 

--- a/packages/EXAMPLE-MCP-PROVIDER/README.md
+++ b/packages/EXAMPLE-MCP-PROVIDER/README.md
@@ -1,3 +1,3 @@
 # For Internal Use Only
 
-This npm package is currently for internal use only. Its contents may change at any time with no gaurantee of compatibility with prior versions.
+This npm package is currently for internal use only. Its contents may change at any time with no guarantee of compatibility with prior versions.

--- a/packages/EXAMPLE-MCP-PROVIDER/package.json
+++ b/packages/EXAMPLE-MCP-PROVIDER/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/EXAMPLE-MCP-PROVIDER",
-  "description": "(For Interal Use Only) YOUR DESCRIPTION GOES HERE",
+  "description": "(For Internal Use Only) YOUR DESCRIPTION GOES HERE",
   "version": "0.0.1-alpha.1",
   "author": "Salesforce",
   "license": "Apache-2.0",

--- a/packages/EXAMPLE-MCP-PROVIDER/src/provider.ts
+++ b/packages/EXAMPLE-MCP-PROVIDER/src/provider.ts
@@ -2,7 +2,7 @@ import { McpProvider, McpTool, Services } from "@salesforce/mcp-provider-api";
 import { ExampleMcpTool } from "./tools/example_tool.js";
 
 /**
- * Example MCPProvider for demonstration puproses
+ * Example MCPProvider for demonstration purposes
  */
 export class ExampleMcpProvider extends McpProvider {
   // Must return a name for your McpProvider. It is recommended to make this match the class name

--- a/packages/EXAMPLE-MCP-PROVIDER/src/tools/example_tool.ts
+++ b/packages/EXAMPLE-MCP-PROVIDER/src/tools/example_tool.ts
@@ -22,7 +22,7 @@ type InputArgsShape = typeof exampleInputSchema.shape;
 type OutputArgsShape = z.ZodRawShape;
 
 /**
- * Example tool for demonstration puproses
+ * Example tool for demonstration purposes
  */
 export class ExampleMcpTool extends McpTool<InputArgsShape, OutputArgsShape> {
   private readonly telemetryService: TelemetryService;
@@ -43,8 +43,6 @@ export class ExampleMcpTool extends McpTool<InputArgsShape, OutputArgsShape> {
   }
 
   // Must return the name of your tool.
-  // For internal naming guidelines see:
-  //  https://confluence.internal.salesforce.com/spaces/DOCTEAM/pages/1166876463/MCP+Server+Terminology+and+Style+Guide
   public getName(): string {
     return "example_tool";
   }

--- a/packages/EXAMPLE-MCP-PROVIDER/test/tools/sf-example-tool.test.ts
+++ b/packages/EXAMPLE-MCP-PROVIDER/test/tools/sf-example-tool.test.ts
@@ -13,7 +13,7 @@ describe("Tests for ExampleMcpTool", () => {
   });
 
   it("When getReleaseState is called, then 'non-ga' is returned", () => {
-    expect(tool.getReleaseState()).toEqual(ReleaseState.NON_GA); // Make sure this truely reflects what you want
+    expect(tool.getReleaseState()).toEqual(ReleaseState.NON_GA); // Make sure this truly reflects what you want
   })
 
   it("When getToolsets is called, then 'other' is returned", () => {

--- a/packages/mcp-provider-api/README.md
+++ b/packages/mcp-provider-api/README.md
@@ -1,3 +1,3 @@
 # For Internal Use Only
 
-This npm package is currently for internal use only. Its contents may change at any time with no gaurantee of compatibility with prior versions.
+This npm package is currently for internal use only. Its contents may change at any time with no guarantee of compatibility with prior versions.

--- a/packages/mcp-provider-code-analyzer/README.md
+++ b/packages/mcp-provider-code-analyzer/README.md
@@ -1,3 +1,3 @@
 # For Internal Use Only
 
-This npm package is currently for internal use only. Its contents may change at any time with no gaurantee of compatibility with prior versions.
+This npm package is currently for internal use only. Its contents may change at any time with no guarantee of compatibility with prior versions.

--- a/packages/mcp-provider-code-analyzer/package.json
+++ b/packages/mcp-provider-code-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/mcp-provider-code-analyzer",
-  "description": "(For Interal Use Only) Provides MCP Tools for Salesforce Code Analyzer to a MCP Server",
+  "description": "(For Internal Use Only) Provides MCP Tools for Salesforce Code Analyzer to an MCP Server",
   "version": "0.7.1",
   "author": "Salesforce",
   "license": "Apache-2.0",

--- a/packages/mcp-provider-devops/README.md
+++ b/packages/mcp-provider-devops/README.md
@@ -1,3 +1,3 @@
 # For Internal Use Only
 
-This npm package is currently for internal use only. Its contents may change at any time with no gaurantee of compatibility with prior versions.
+This npm package is currently for internal use only. Its contents may change at any time with no guarantee of compatibility with prior versions.

--- a/packages/mcp-provider-devops/src/tools/sfDevopsListWorkItems.ts
+++ b/packages/mcp-provider-devops/src/tools/sfDevopsListWorkItems.ts
@@ -40,7 +40,7 @@ export class SfDevopsListWorkItems extends McpTool<InputArgsShape, OutputArgsSha
   public getConfig(): McpToolConfig<InputArgsShape, OutputArgsShape> {
     return {
       title: "List DevOps Work Items",
-      description: `List all the work items for a specific  DevOps Center project.
+      description: `List all the work items for a specific DevOps Center project.
 
       **Terminology:** Treat "DevOps Center", "DOCe", and "DoCe" as the same product/org context.
       

--- a/packages/mcp-provider-dx-core/src/tools/create_org_snapshot.ts
+++ b/packages/mcp-provider-dx-core/src/tools/create_org_snapshot.ts
@@ -42,7 +42,7 @@ const createOrgSnapshotParams = z.object({
   sourceOrg: usernameOrAliasParam.describe(
     'The org username or alias to create a snapshot of, use the #get_username tool to get the default target org if unsure',
   ),
-  description: z.string().describe(' Description of snapshot.').optional(),
+  description: z.string().describe('Description of snapshot.').optional(),
   name: z.string().describe('Unique name of snapshot').max(15).default(Date.now().toString().substring(0, 15)),
 });
 

--- a/packages/mcp-provider-dx-core/src/tools/delete_org.ts
+++ b/packages/mcp-provider-dx-core/src/tools/delete_org.ts
@@ -61,7 +61,7 @@ export class DeleteOrgMcpTool extends McpTool<InputArgsShape, OutputArgsShape> {
   public getConfig(): McpToolConfig<InputArgsShape, OutputArgsShape> {
     return {
       title: 'Delete an Org',
-      description: `Deletes specified salesforce org.
+      description: `Deletes specified Salesforce org.
 
 AGENT INSTRUCTIONS:
 ALWAYS confirm with the user before deleting an org

--- a/packages/mcp-provider-dx-core/src/tools/get_username.ts
+++ b/packages/mcp-provider-dx-core/src/tools/get_username.ts
@@ -113,8 +113,8 @@ WHEN TO USE THIS TOOL:
 - When uncertain which org username a user wants for Salesforce operations.
 
 To resolve the default org username, set the defaultTargetOrg param to true and defaultDevHub to false.
-To resole the default devhub org username, set the defaultTargetOrg param to false and defaultDevHub to true.
-If it's not clear which type of org to resolve, set both defaultTargetOrg and defaultDevHub to false to an allow-listed org username available.
+To resolve the default devhub org username, set the defaultTargetOrg param to false and defaultDevHub to true.
+If it's not clear which type of org to resolve, set both defaultTargetOrg and defaultDevHub to false to get an available allow-listed org username.
 `,
       inputSchema: getUsernameParamsSchema.shape,
       outputSchema: undefined,

--- a/packages/mcp-provider-mobile-web/README.md
+++ b/packages/mcp-provider-mobile-web/README.md
@@ -1,3 +1,3 @@
 # For Internal Use Only
 
-This npm package is currently for internal use only. Its contents may change at any time with no gaurantee of compatibility with prior versions.
+This npm package is currently for internal use only. Its contents may change at any time with no guarantee of compatibility with prior versions.

--- a/packages/mcp/DEVELOPING.md
+++ b/packages/mcp/DEVELOPING.md
@@ -47,7 +47,7 @@ Use this guide to learn how to contribute to the Salesforce DX MCP Server.
    }
    ```
 
-1. Start the Salesforce DX MCP server and call the tools using natural language prompts. See [./README.md] for details.
+1. Start the Salesforce DX MCP server and call the tools using natural language prompts. See [README.md](./README.md) for details.
 1. Write tests and run them: `yarn test`. See [Unit Tests](#unit-tests) for details.
 1. See all changed files and verify that you want to commit them: `git status`.
 1. Add all files to staging: `git add .` (Make sure you include the period!)


### PR DESCRIPTION
## Summary

Fixes 20+ typos, grammar issues, formatting inconsistencies, and broken links across documentation and source files:

**Typos**
- "gaurantee" → "guarantee" in 5 package READMEs
- "Interal" → "Internal" in 2 package.json descriptions
- "puproses" → "purposes" in EXAMPLE provider (2 files)
- "truely" → "truly" in EXAMPLE provider test
- "resole" → "resolve" in `get_username` tool description
- "the the" → "the" in DEVELOPING.md

**Formatting & grammar**
- Double period in `aura-experts` toolset description
- Broken sentence in `create_lwc_component_from_prd` description (`"structure. and"`)
- Tool name mismatch: `run_apex_tests` (plural) in prose vs `run_apex_test` (singular) everywhere else
- Missing `(NON-GA)` label on `create_mobile_lwc_payments`
- Trailing space before `]` in markdown link
- Double space in `sfDevopsListWorkItems` tool description
- Leading space in `create_org_snapshot` description param
- Lowercase `salesforce` → `Salesforce` in `delete_org` description
- Garbled sentence in `get_username` tool description
- Grammar fix in Dependabot section
- "a MCP" → "an MCP" in code-analyzer package.json

**Structural**
- Broken markdown link syntax in `packages/mcp/DEVELOPING.md`
- Removed internal Confluence URL from public EXAMPLE provider

## Test plan

- [ ] All changes are in string literals, markdown, and package.json descriptions — no logic changes
- [ ] `yarn build` should pass unchanged
- [ ] Verify rendered markdown in GitHub preview