### PR TITLE
fix: correct .default() misuse, API payload typo, and wrong tool name

### DIFF
--- a/packages/mcp-provider-devops/src/tools/sfDevopsListWorkItems.ts
+++ b/packages/mcp-provider-devops/src/tools/sfDevopsListWorkItems.ts
@@ -47,7 +47,7 @@ export class SfDevopsListWorkItems extends McpTool<InputArgsShape, OutputArgsSha
 **Input:**
 - Either username (example devops-center@example.com) or alias (example myDevOpsOrg) is required.
       
-      **MANDATORY:** If the DevOps Center org is not given, use the 'sf-list-all-orgs' tool to list all orgs. 
+      **MANDATORY:** If the DevOps Center org is not given, use the 'list_all_orgs' tool to list all orgs. 
       The list will indicate which org is DevOps Center, or Sandbox if possible. If these details are not provided in the list, 
       ask the user to specify which org is DevOps Center org. Only proceed after the user has selected the DevOps Center org.
 

--- a/packages/mcp-provider-dx-core/src/tools/create_org_snapshot.ts
+++ b/packages/mcp-provider-dx-core/src/tools/create_org_snapshot.ts
@@ -96,7 +96,7 @@ create a snapshot of my MyScratch in myDevHub`,
         SourceOrg: sourceOrgId,
         Description: input.description,
         SnapshotName: input.name,
-        Content: 'metadatadata',
+        Content: 'metadata',
       });
 
       if (createResponse.success === false) {

--- a/packages/mcp-provider-dx-core/src/tools/run_apex_test.ts
+++ b/packages/mcp-provider-dx-core/src/tools/run_apex_test.ts
@@ -70,7 +70,7 @@ RunSpecifiedTests="Run the Apex tests I specify, these will be specified in the 
       'Weather to wait for the test to finish (false) or enque the Apex tests and return the test run id (true)',
     ),
   suiteName: z.string().describe('a suite of apex test classes to run').optional(),
-  testRunId: z.string().default('an id of an in-progress, or completed apex test run').optional(),
+  testRunId: z.string().describe('an id of an in-progress, or completed apex test run').optional(),
   verbose: z
     .boolean()
     .default(false)


### PR DESCRIPTION
## Summary

Three bug fixes in tool definitions:

### 1. `testRunId` uses `.default()` instead of `.describe()` (run_apex_test.ts)
The `testRunId` parameter uses `.default('an id of an in-progress, or completed apex test run')` — this sets the literal description string as the **default value** instead of documenting the parameter. If no `testRunId` is provided, zod will populate it with that description string rather than leaving it undefined.

**Fix:** Change `.default()` to `.describe()`.

### 2. `'metadatadata'` typo in OrgSnapshot API payload (create_org_snapshot.ts)
The `Content` field sent to the Salesforce `OrgSnapshot.create()` API is `'metadatadata'` instead of `'metadata'`. This could cause the API call to fail or behave unexpectedly.

**Fix:** Change `'metadatadata'` to `'metadata'`.

### 3. Wrong tool name in agent instructions (sfDevopsListWorkItems.ts)
The tool description references `'sf-list-all-orgs'` but the actual registered tool name is `'list_all_orgs'`. An LLM following these instructions would attempt to call a nonexistent tool.

**Fix:** Change `'sf-list-all-orgs'` to `'list_all_orgs'`.

## Test plan

- [ ] Verify `testRunId` param no longer has a default value (was description string, now uses `.describe()`)
- [ ] Verify `create_org_snapshot` sends correct `Content: 'metadata'` to Salesforce API
- [ ] Verify `list_devops_center_work_items` tool description references correct tool name `list_all_orgs`