### PR TITLE
docs: fix typos, grammar errors, and swapped comments in source

### DIFF
--- a/packages/mcp-provider-api/src/provider.ts
+++ b/packages/mcp-provider-api/src/provider.ts
@@ -44,7 +44,7 @@ export abstract class McpProvider implements Versioned {
   }
 
   /**
-   * This method allows the server to check that this provider is return compatible prompts, resources, and tools to be registered.
+   * This method allows the server to check that this provider is returning compatible prompts, resources, and tools to be registered.
    * IMPORTANT: Subclasses should not override this method.
    */
   public getVersion(): SemVer {

--- a/packages/mcp-provider-code-analyzer/src/tools/query_code_analyzer_results.ts
+++ b/packages/mcp-provider-code-analyzer/src/tools/query_code_analyzer_results.ts
@@ -27,7 +27,7 @@ Examples (natural language → selector/topN):
 `;
 
 export const inputSchema = z.object({
-    resultsFile: z.string().describe("Absolute path to a results JSON file produced by the code analyzer., if results file is not provided, call run_code_analyzer tool to generate a results file first."),
+    resultsFile: z.string().describe("Absolute path to a results JSON file produced by the code analyzer. If a results file is not provided, call run_code_analyzer tool to generate a results file first."),
     selector: z.string().describe('Selector (same semantics as "list_code_analyzer_rules"): colon-separated tokens with optional OR-groups in parentheses, e.g., "Security:(pmd,eslint):High".'),
     topN: z.number().int().positive().max(1000).default(DEFAULT_TOPN_POLICY_LIMIT)
         .describe(`Return at most this many violations after filtering and sorting (default ${DEFAULT_TOPN_POLICY_LIMIT}). Never increase this number unless the user explicitly asks for a larger result set. Requests >${DEFAULT_TOPN_POLICY_LIMIT} require allowLargeResultSet=true.`),

--- a/packages/mcp-provider-devops/src/tools/sfDevopsPromoteWorkItem.ts
+++ b/packages/mcp-provider-devops/src/tools/sfDevopsPromoteWorkItem.ts
@@ -65,14 +65,11 @@ export class SfDevopsPromoteWorkItem extends McpTool<InputArgsShape, OutputArgsS
       - Never promote without explicit user confirmation of workitems.
 
       **Output:**
-      - JSON with promotion requestId (if available) and any error details.
+      A JSON object containing the promotion request ID, the org details, and any relevant status or tracking information.
 
       **Next steps:**
       - Suggest how to track promotion status using the returned requestId or the DevOps Center UI.
       - If applicable, prompt the user to promote to the next stage after validation.
-
-      **Output:**
-      A JSON object containing the promotion request ID, the org details, and any relevant status or tracking information.
       `,
       inputSchema: inputSchema.shape,
       outputSchema: undefined,

--- a/packages/mcp-provider-dx-core/src/shared/utils.ts
+++ b/packages/mcp-provider-dx-core/src/shared/utils.ts
@@ -42,8 +42,8 @@ export function sanitizePath(projectPath: string): boolean {
   // Check for various traversal patterns
   const hasTraversal =
     normalizedProjectPath.includes('..') ||
-    normalizedProjectPath.includes('\u2025') || // Unicode horizontal ellipsis
-    normalizedProjectPath.includes('\u2026'); // Unicode vertical ellipsis
+    normalizedProjectPath.includes('\u2025') || // Unicode two dot leader
+    normalizedProjectPath.includes('\u2026'); // Unicode horizontal ellipsis
 
   // `path.isAbsolute` doesn't cover Windows's drive-relative path:
   // https://github.com/nodejs/node/issues/56766

--- a/packages/mcp-provider-dx-core/src/tools/create_org_snapshot.ts
+++ b/packages/mcp-provider-dx-core/src/tools/create_org_snapshot.ts
@@ -100,7 +100,7 @@ create a snapshot of my MyScratch in myDevHub`,
       });
 
       if (createResponse.success === false) {
-        return textResponse(`An error while created the org snapshot: ${JSON.stringify(createResponse)}`, true);
+        return textResponse(`An error occurred while creating the org snapshot: ${JSON.stringify(createResponse)}`, true);
       }
       const result = await devHubConnection.singleRecordQuery(`SELECT Id,
               SnapshotName,

--- a/packages/mcp-provider-dx-core/src/tools/deploy_metadata.ts
+++ b/packages/mcp-provider-dx-core/src/tools/deploy_metadata.ts
@@ -42,7 +42,7 @@ import { textResponse } from '../shared/utils.js';
  */
 
 export const deployMetadataParams = z.object({
-  ignoreConflicts: z.boolean().describe(' Ignore conflicts and deploy local files, even if they overwrite changes in the org.').optional(),
+  ignoreConflicts: z.boolean().describe('Ignore conflicts and deploy local files, even if they overwrite changes in the org.').optional(),
   sourceDir: z
     .array(z.string())
     .describe('Path to the local source files to deploy. Leave this unset if the user is vague about what to deploy.')
@@ -59,7 +59,7 @@ export const deployMetadataParams = z.object({
       `Apex test level to use during deployment.
 
 AGENT INSTRUCTIONS
-Set this only if the user specifically ask to run apex tests in some of these ways:
+Set this only if the user specifically asks to run Apex tests in some of these ways:
 
 NoTestRun="No tests are run"
 RunLocalTests="Run all tests in the org, except the ones that originate from installed managed and unlocked packages."
@@ -73,7 +73,7 @@ Don't set this param if "apexTests" is also set.
     .describe(
       `Apex tests classes to run.
 
-Set this param if the user ask an Apex test to be run during deployment.
+Set this param if the user asks for an Apex test to be run during deployment.
 `,
     )
     .optional(),

--- a/packages/mcp-provider-dx-core/src/tools/resume_tool_operation.ts
+++ b/packages/mcp-provider-dx-core/src/tools/resume_tool_operation.ts
@@ -132,7 +132,7 @@ Report on my org snapshot`,
       case resumableIdPrefixes.get('orgSnapshot'):
         return resumeOrgSnapshot(connection, input.jobId, input.wait);
       default:
-        return textResponse(`The job id: ${input.jobId} is not resumeable.`, true);
+        return textResponse(`The job id: ${input.jobId} is not resumable.`, true);
     }
   }
 }

--- a/packages/mcp-provider-dx-core/src/tools/retrieve_metadata.ts
+++ b/packages/mcp-provider-dx-core/src/tools/retrieve_metadata.ts
@@ -152,7 +152,7 @@ Retrieve X metadata from my org and ignore any conflicts between the local proje
         output: project.getDefaultPackage().fullPath,
       });
 
-      // polling freq. is set dynamically by SDR based no the component set size.
+      // polling freq. is set dynamically by SDR based on the component set size.
       const result = await retrieve.pollStatus({
         timeout: Duration.minutes(10),
       });

--- a/packages/mcp-provider-dx-core/src/tools/run_apex_test.ts
+++ b/packages/mcp-provider-dx-core/src/tools/run_apex_test.ts
@@ -67,7 +67,7 @@ RunSpecifiedTests="Run the Apex tests I specify, these will be specified in the 
     .boolean()
     .default(false)
     .describe(
-      'Weather to wait for the test to finish (false) or enque the Apex tests and return the test run id (true)',
+      'Whether to wait for the test to finish (false) or enqueue the Apex tests and return the test run id (true)',
     ),
   suiteName: z.string().describe('a suite of apex test classes to run').optional(),
   testRunId: z.string().default('an id of an in-progress, or completed apex test run').optional(),

--- a/packages/mcp-provider-scale-products/src/shared/utils.ts
+++ b/packages/mcp-provider-scale-products/src/shared/utils.ts
@@ -30,8 +30,8 @@ export function sanitizePath(projectPath: string): boolean {
   // Check for various traversal patterns
   const hasTraversal =
     normalizedProjectPath.includes("..") ||
-    normalizedProjectPath.includes("\u2025") || // Unicode horizontal ellipsis
-    normalizedProjectPath.includes("\u2026"); // Unicode vertical ellipsis
+    normalizedProjectPath.includes("\u2025") || // Unicode two dot leader
+    normalizedProjectPath.includes("\u2026"); // Unicode horizontal ellipsis
 
   // `path.isAbsolute` doesn't cover Windows's drive-relative path:
   // https://github.com/nodejs/node/issues/56766

--- a/packages/mcp/src/utils/auth.ts
+++ b/packages/mcp/src/utils/auth.ts
@@ -140,7 +140,7 @@ async function getDefaultConfig(
 
   if (!value || typeof value !== 'string' || !path) return undefined;
 
-  // Return an typed object with only the necessary properties
+  // Return a typed object with only the necessary properties
   // This reduces assertions and lowers context returned to the LLM
   return { key, location, value, path } as OrgConfigInfo;
 }


### PR DESCRIPTION
## Summary

Fixes 13 typos, grammar errors, and incorrect comments across tool descriptions, error messages, and code comments:

**Spelling**
- "Weather" → "Whether" and "enque" → "enqueue" in `run_apex_test` parameter description
- "resumeable" → "resumable" in `resume_tool_operation` error message
- "based no the" → "based on the" in `retrieve_metadata` comment

**Grammar**
- "An error while created the org snapshot" → "An error occurred while creating the org snapshot"
- "an typed" → "a typed" in auth utility comment
- "user specifically ask" → "asks" in `deploy_metadata` description
- "user ask an Apex test" → "user asks for an Apex test" in `deploy_metadata` description
- "is return compatible" → "is returning compatible" in provider JSDoc
- Leading space in `deploy_metadata` `.describe()` string

**Incorrect comments**
- Swapped Unicode character comments in both `dx-core/utils.ts` and `scale-products/utils.ts`: `\u2025` is the two dot leader (not horizontal ellipsis) and `\u2026` is the horizontal ellipsis (not vertical ellipsis)

**Copy-paste error**
- Duplicate `**Output:**` section in `sfDevopsPromoteWorkItem` tool description — consolidated into single section

**Punctuation**
- Extra period before comma in `query_code_analyzer_results` description: `"analyzer., if"` → `"analyzer. If a"`

## Test plan

- [ ] All changes are in string literals, comments, and error messages — no logic changes
- [ ] `yarn build` should pass unchanged