### PR TITLE
W-22550530: Prevent SOQL injection in DevOps Work Item and Pipeline queries

### DIFF
--- a/packages/mcp-provider-devops/src/getPipelineMP.ts
+++ b/packages/mcp-provider-devops/src/getPipelineMP.ts
@@ -1,4 +1,5 @@
 import type { Connection } from "@salesforce/core";
+import { validateSalesforceId } from "./shared/soqlUtils.js";
 
 export interface DevopsPipelineRecordMP {
     Id: string;
@@ -13,10 +14,13 @@ export interface DevopsPipelineRecordMP {
  */
 export async function getPipelineMP(connection: Connection, projectId: string): Promise<DevopsPipelineRecordMP | null | any> {
     try {
+        // Validate projectId to prevent SOQL injection
+        const validatedProjectId = validateSalesforceId(projectId, 'projectId');
+
         const query = `
             SELECT Id, Name, sf_devops__Activated__c, sf_devops__Project__c
             FROM sf_devops__Pipeline__c
-            WHERE sf_devops__Project__c = '${projectId}'
+            WHERE sf_devops__Project__c = '${validatedProjectId}'
               AND sf_devops__Activated__c = true
             LIMIT 1
         `;

--- a/packages/mcp-provider-devops/src/getPipelineStagesMP.ts
+++ b/packages/mcp-provider-devops/src/getPipelineStagesMP.ts
@@ -1,4 +1,5 @@
 import type { Connection } from "@salesforce/core";
+import { validateSalesforceId } from "./shared/soqlUtils.js";
 
 export interface PipelineStageRecordMP {
     Id: string;
@@ -17,6 +18,9 @@ export interface PipelineStageRecordMP {
  */
 export async function fetchPipelineStagesMP(connection: Connection, pipelineId: string): Promise<PipelineStageRecordMP[] | any> {
     try {
+        // Validate pipelineId to prevent SOQL injection
+        const validatedPipelineId = validateSalesforceId(pipelineId, 'pipelineId');
+
         const query = `
             SELECT
                 Id,
@@ -28,7 +32,7 @@ export async function fetchPipelineStagesMP(connection: Connection, pipelineId: 
                 sf_devops__Next_Stage__c,
                 sf_devops__Next_Stage__r.Name
             FROM sf_devops__Pipeline_Stage__c
-            WHERE sf_devops__Pipeline__c = '${pipelineId}'
+            WHERE sf_devops__Pipeline__c = '${validatedPipelineId}'
         `;
         const result: any = await connection.query(query);
         const records: any[] = result?.records || [];

--- a/packages/mcp-provider-devops/src/getWorkItems.ts
+++ b/packages/mcp-provider-devops/src/getWorkItems.ts
@@ -1,5 +1,6 @@
 import { type Connection } from "@salesforce/core";
 import { computeFirstStageId, fetchPipelineStages, getBranchNameFromStage, getPipelineIdForProject, findStageById, resolveTargetStageId } from "./shared/pipelineUtils.js";
+import { validateSalesforceId, validateWorkItemName } from "./shared/soqlUtils.js";
 import type { WorkItem } from "./types/WorkItem.js";
 
 type ProjectStagesContext = { pipelineId: string; stages: any[]; firstStageId: string | undefined };
@@ -203,6 +204,9 @@ function mapRawItemToWorkItem(item: any, ctx: ProjectStagesContext | null, provi
 
 export async function fetchWorkItems(connection: Connection, projectId: string): Promise<WorkItem[] | any> {
     try {
+        // Validate projectId to prevent SOQL injection
+        const validatedProjectId = validateSalesforceId(projectId, 'projectId');
+
         const query = `
             SELECT
                 Id,
@@ -220,7 +224,7 @@ export async function fetchWorkItems(connection: Connection, projectId: string):
                 DevopsPipelineStageId,
                 DevopsProjectId
             FROM WorkItem
-            WHERE DevopsProjectId = '${projectId}'
+            WHERE DevopsProjectId = '${validatedProjectId}'
         `;
         
         
@@ -246,6 +250,9 @@ export async function fetchWorkItems(connection: Connection, projectId: string):
  */
 export async function fetchWorkItemByName(connection: Connection, workItemName: string): Promise<WorkItem | null | any> {
     try {
+        // Validate workItemName to prevent SOQL injection
+        const validatedWorkItemName = validateWorkItemName(workItemName);
+
         const query = `
             SELECT
                 Id,
@@ -263,7 +270,7 @@ export async function fetchWorkItemByName(connection: Connection, workItemName: 
                 DevopsPipelineStageId,
                 DevopsProjectId
             FROM WorkItem
-            WHERE Name = '${workItemName}'
+            WHERE Name = '${validatedWorkItemName}'
             LIMIT 1
         `;
 

--- a/packages/mcp-provider-devops/src/getWorkItemsMP.ts
+++ b/packages/mcp-provider-devops/src/getWorkItemsMP.ts
@@ -2,6 +2,7 @@ import type { Connection } from "@salesforce/core";
 import type { WorkItem } from "./types/WorkItem.js";
 import { getPipelineMP } from "./getPipelineMP.js";
 import { fetchPipelineStagesMP } from "./getPipelineStagesMP.js";
+import { validateSalesforceId, validateWorkItemName } from "./shared/soqlUtils.js";
 
 
 function inferRepoTypeFromUrl(repoUrl: string): string {
@@ -56,6 +57,9 @@ export async function fetchWorkItemByNameMP(connection: Connection, workItemName
 }
 
 async function queryWorkItemByName(connection: any, workItemName: string): Promise<any | null> {
+    // Validate workItemName to prevent SOQL injection
+    const validatedWorkItemName = validateWorkItemName(workItemName);
+
     const query = `
         SELECT Id,
         Name,
@@ -64,10 +68,10 @@ async function queryWorkItemByName(connection: any, workItemName: string): Promi
         sf_devops__State__c,
         sf_devops__Concluded__c,
         sf_devops__Assigned_To__c, sf_devops__Assigned_To__r.Name,
-        sf_devops__Branch__c, sf_devops__Branch__r.Name, 
+        sf_devops__Branch__c, sf_devops__Branch__r.Name,
         sf_devops__Branch__r.sf_devops__Repository__r.sf_devops__Url__c, sf_devops__Project__c
         FROM sf_devops__Work_Item__c
-        WHERE Name = '${workItemName}'
+        WHERE Name = '${validatedWorkItemName}'
         LIMIT 1
     `;
     const result: any = await connection.query(query);
@@ -118,10 +122,14 @@ function orderStagesFromFirst(idToStage: Map<string, any>, firstStageId?: string
 
 async function getCompletedStageIds(connection: any, workItemId: string): Promise<Set<string>> {
     const completed = new Set<string>();
+
+    // Validate workItemId to prevent SOQL injection
+    const validatedWorkItemId = validateSalesforceId(workItemId, 'workItemId');
+
     const q = `
         SELECT Id, sf_devops__Pipeline_Stage__c, sf_devops__Deployment_Result__r.sf_devops__Completion_Date__c
         FROM sf_devops__Work_Item_Promote__c
-        WHERE sf_devops__Work_Item__c = '${workItemId}'
+        WHERE sf_devops__Work_Item__c = '${validatedWorkItemId}'
           AND sf_devops__Deployment_Result__r.sf_devops__Completion_Date__c != NULL
           AND sf_devops__Deployment_Result__r.sf_devops__Deployment_Id__c != NULL
     `;

--- a/packages/mcp-provider-devops/src/shared/soqlUtils.ts
+++ b/packages/mcp-provider-devops/src/shared/soqlUtils.ts
@@ -77,13 +77,12 @@ export function containsSqlInjectionPatterns(value: string): boolean {
         /\bUPDATE\b/i,  // UPDATE keyword
         /\bDELETE\b/i,  // DELETE keyword
         /\bEXEC\b/i,    // EXEC keyword
-        /'/,            // Unescaped single quote (will be escaped later)
     ];
 
-    // Allow single quotes since we'll escape them, but check for injection patterns first
+    // Check for injection patterns (excluding quotes which we'll escape)
     const withoutQuotes = trimmed.replace(/'/g, '');
-    return injectionPatterns.slice(0, -1).some(pattern => pattern.test(withoutQuotes)) ||
-           (trimmed.includes("'") && injectionPatterns.slice(0, -1).some(pattern => pattern.test(trimmed)));
+    return injectionPatterns.some(pattern => pattern.test(withoutQuotes)) ||
+           (trimmed.includes("'") && injectionPatterns.some(pattern => pattern.test(trimmed)));
 }
 
 /**
@@ -106,10 +105,10 @@ export function validateWorkItemName(name: string): string {
 
     // Also allow alphanumeric names with spaces, hyphens, and underscores (for managed package work items)
     // but ensure no special characters that could be used for injection
-    const safeNamePattern = /^[a-zA-Z0-9\s_-]+$/;
+    const safeNamePattern = /^[a-zA-Z0-9\s_'-]+$/;
     if (safeNamePattern.test(trimmed)) {
         return escapeSoqlString(trimmed);
     }
 
-    throw new Error(`Invalid work item name format: ${name}. Expected WI-XXXXXXX or alphanumeric name without special characters`);
+    throw new Error(`Invalid work item name format: ${name}`);
 }

--- a/packages/mcp-provider-devops/src/shared/soqlUtils.ts
+++ b/packages/mcp-provider-devops/src/shared/soqlUtils.ts
@@ -54,13 +54,62 @@ export function isValidWorkItemName(name: string): boolean {
 }
 
 /**
+ * Checks if a string contains potential SQL injection patterns.
+ * Returns true if injection patterns are detected.
+ */
+export function containsSqlInjectionPatterns(value: string): boolean {
+    if (typeof value !== 'string') {
+        return true;
+    }
+
+    const trimmed = value.trim();
+
+    // Check for common SQL injection patterns
+    const injectionPatterns = [
+        /--/,           // SQL comment
+        /;/,            // Statement terminator
+        /\bOR\b/i,      // OR keyword
+        /\bAND\b/i,     // AND keyword
+        /\bUNION\b/i,   // UNION keyword
+        /\bSELECT\b/i,  // SELECT keyword
+        /\bDROP\b/i,    // DROP keyword
+        /\bINSERT\b/i,  // INSERT keyword
+        /\bUPDATE\b/i,  // UPDATE keyword
+        /\bDELETE\b/i,  // DELETE keyword
+        /\bEXEC\b/i,    // EXEC keyword
+        /'/,            // Unescaped single quote (will be escaped later)
+    ];
+
+    // Allow single quotes since we'll escape them, but check for injection patterns first
+    const withoutQuotes = trimmed.replace(/'/g, '');
+    return injectionPatterns.slice(0, -1).some(pattern => pattern.test(withoutQuotes)) ||
+           (trimmed.includes("'") && injectionPatterns.slice(0, -1).some(pattern => pattern.test(trimmed)));
+}
+
+/**
  * Validates and escapes a work item name for SOQL.
- * Throws an error if the format is invalid.
+ * Accepts WI-XXXXXXX format or any alphanumeric string without injection patterns.
+ * Throws an error if the format is invalid or contains injection attempts.
  */
 export function validateWorkItemName(name: string): string {
     const trimmed = name.trim();
-    if (!isValidWorkItemName(trimmed)) {
-        throw new Error(`Invalid work item name format: ${name}. Expected format: WI-XXXXXXX`);
+
+    // Check for SQL injection patterns first
+    if (containsSqlInjectionPatterns(trimmed)) {
+        throw new Error(`Invalid work item name: potential SQL injection detected in "${name}"`);
     }
-    return escapeSoqlString(trimmed);
+
+    // If it matches the standard WI-XXXXXXX format, it's valid
+    if (isValidWorkItemName(trimmed)) {
+        return escapeSoqlString(trimmed);
+    }
+
+    // Also allow alphanumeric names with spaces, hyphens, and underscores (for managed package work items)
+    // but ensure no special characters that could be used for injection
+    const safeNamePattern = /^[a-zA-Z0-9\s_-]+$/;
+    if (safeNamePattern.test(trimmed)) {
+        return escapeSoqlString(trimmed);
+    }
+
+    throw new Error(`Invalid work item name format: ${name}. Expected WI-XXXXXXX or alphanumeric name without special characters`);
 }

--- a/packages/mcp-provider-devops/src/shared/soqlUtils.ts
+++ b/packages/mcp-provider-devops/src/shared/soqlUtils.ts
@@ -1,0 +1,66 @@
+/**
+ * Utility functions for safe SOQL query construction
+ */
+
+/**
+ * Validates that a string is a valid Salesforce ID (15 or 18 characters).
+ * Returns true if valid, false otherwise.
+ */
+export function isValidSalesforceId(id: string): boolean {
+    if (typeof id !== 'string') {
+        return false;
+    }
+    // Salesforce IDs are either 15 or 18 characters, alphanumeric
+    const trimmed = id.trim();
+    const idPattern = /^[a-zA-Z0-9]{15}$|^[a-zA-Z0-9]{18}$/;
+    return idPattern.test(trimmed);
+}
+
+/**
+ * Escapes single quotes in a string for use in SOQL queries.
+ * Throws an error if the value contains SQL injection attempts.
+ */
+export function escapeSoqlString(value: string): string {
+    if (typeof value !== 'string') {
+        throw new Error('SOQL escape requires string input');
+    }
+
+    // Escape single quotes by doubling them (SOQL standard)
+    return value.replace(/'/g, "\\'");
+}
+
+/**
+ * Validates and returns a Salesforce ID, or throws an error.
+ * Use this for ID fields to prevent injection.
+ */
+export function validateSalesforceId(id: string, fieldName: string = 'ID'): string {
+    if (!isValidSalesforceId(id)) {
+        throw new Error(`Invalid Salesforce ID format for ${fieldName}: ${id}`);
+    }
+    return id.trim();
+}
+
+/**
+ * Validates a work item name format (WI-XXXXXXX).
+ * Returns true if valid, false otherwise.
+ */
+export function isValidWorkItemName(name: string): boolean {
+    if (typeof name !== 'string') {
+        return false;
+    }
+    // Work item names follow the pattern: WI- followed by digits
+    const workItemPattern = /^WI-\d+$/;
+    return workItemPattern.test(name.trim());
+}
+
+/**
+ * Validates and escapes a work item name for SOQL.
+ * Throws an error if the format is invalid.
+ */
+export function validateWorkItemName(name: string): string {
+    const trimmed = name.trim();
+    if (!isValidWorkItemName(trimmed)) {
+        throw new Error(`Invalid work item name format: ${name}. Expected format: WI-XXXXXXX`);
+    }
+    return escapeSoqlString(trimmed);
+}

--- a/packages/mcp-provider-devops/test/getPipelineMP.test.ts
+++ b/packages/mcp-provider-devops/test/getPipelineMP.test.ts
@@ -3,9 +3,9 @@ import { getPipelineMP } from '../src/getPipelineMP.js';
 
 describe('getPipelineMP', () => {
   it('should fetch a pipeline successfully', async () => {
-    const mockConnection = { query: vi.fn().mockResolvedValue({ records: [{ Id: 'PL-001', Name: 'Pipeline 1', sf_devops__Activated__c: true, sf_devops__Project__c: 'P-001' }] }) };
+    const mockConnection = { query: vi.fn().mockResolvedValue({ records: [{ Id: 'PL-001', Name: 'Pipeline 1', sf_devops__Activated__c: true, sf_devops__Project__c: 'a0Bxx00000002Cd' }] }) };
 
-    const pipeline = await getPipelineMP(mockConnection, 'P-001');
+    const pipeline = await getPipelineMP(mockConnection, 'a0Bxx00000002Cd');
     expect(pipeline.Id).toBe('PL-001');
     expect(pipeline.Name).toBe('Pipeline 1');
   });
@@ -13,14 +13,14 @@ describe('getPipelineMP', () => {
   it('should return null if no active pipeline is found', async () => {
     const mockConnection = { query: vi.fn().mockResolvedValue({ records: [] }) };
 
-    const pipeline = await getPipelineMP(mockConnection, 'P-001');
+    const pipeline = await getPipelineMP(mockConnection, 'a0Bxx00000002Cd');
     expect(pipeline).toBeNull();
   });
 
   it('should handle errors gracefully', async () => {
     const mockConnection = { query: vi.fn().mockRejectedValue(new Error('Network Error')) };
 
-    const error = await getPipelineMP(mockConnection, 'P-001');
+    const error = await getPipelineMP(mockConnection, 'a0Bxx00000002Cd');
     expect(error.message).toBe('Network Error');
   });
 });

--- a/packages/mcp-provider-devops/test/getPipelineStagesMP.test.ts
+++ b/packages/mcp-provider-devops/test/getPipelineStagesMP.test.ts
@@ -3,9 +3,9 @@ import { fetchPipelineStagesMP } from '../src/getPipelineStagesMP.js';
 
 describe('fetchPipelineStagesMP', () => {
   it('should fetch pipeline stages successfully', async () => {
-    const mockConnection = { query: vi.fn().mockResolvedValue({ records: [{ Id: 'PS-001', Name: 'Stage 1', sf_devops__Pipeline__c: 'P-001' }] }) };
+    const mockConnection = { query: vi.fn().mockResolvedValue({ records: [{ Id: 'PS-001', Name: 'Stage 1', sf_devops__Pipeline__c: 'a0Axx00000001Ab' }] }) };
 
-    const stages = await fetchPipelineStagesMP(mockConnection, 'P-001');
+    const stages = await fetchPipelineStagesMP(mockConnection, 'a0Axx00000001Ab');
     expect(stages).toHaveLength(1);
     expect(stages[0].Id).toBe('PS-001');
     expect(stages[0].Name).toBe('Stage 1');
@@ -14,14 +14,14 @@ describe('fetchPipelineStagesMP', () => {
   it('should return an empty array if no stages are found', async () => {
     const mockConnection = { query: vi.fn().mockResolvedValue({ records: [] }) };
 
-    const stages = await fetchPipelineStagesMP(mockConnection, 'P-001');
+    const stages = await fetchPipelineStagesMP(mockConnection, 'a0Axx00000001Ab');
     expect(stages).toHaveLength(0);
   });
 
   it('should handle errors gracefully', async () => {
     const mockConnection = { query: vi.fn().mockRejectedValue(new Error('Network Error')) };
 
-    const error = await fetchPipelineStagesMP(mockConnection, 'P-001');
+    const error = await fetchPipelineStagesMP(mockConnection, 'a0Axx00000001Ab');
     expect(error.message).toBe('Network Error');
   });
 });

--- a/packages/mcp-provider-devops/test/getWorkItems.test.ts
+++ b/packages/mcp-provider-devops/test/getWorkItems.test.ts
@@ -9,7 +9,7 @@ vi.mock('../src/shared/pipelineUtils');
 
 const mockConnection = {
   query: vi.fn().mockImplementation((query: string) => {
-    if (query.includes("WHERE DevopsProjectId = 'project-001'")) {
+    if (query.includes("WHERE DevopsProjectId = '001xx0000012345'")) {
       return { records: [{ Id: 'WI-0001', Name: 'Test Work Item' }] };
     }
     if (query.includes("WHERE Name IN ('WI-0001', 'WI-0002')")) {
@@ -25,14 +25,14 @@ const mockConnection = {
 
 describe('fetchWorkItems', () => {
   it('should fetch work items successfully', async () => {
-    const workItems = await fetchWorkItems(mockConnection as any, 'project-001');
+    const workItems = await fetchWorkItems(mockConnection as any, '001xx0000012345');
     expect(workItems).toHaveLength(1);
     expect(workItems[0].id).toBe('WI-0001');
   });
 
   it('should fetch work items when no pipeline is linked to the project', async () => {
     (getPipelineIdForProject as any).mockResolvedValueOnce(undefined);
-    const workItems = await fetchWorkItems(mockConnection as any, 'project-001');
+    const workItems = await fetchWorkItems(mockConnection as any, '001xx0000012345');
     expect(workItems).toHaveLength(1);
     expect(workItems[0].id).toBe('WI-0001');
     expect(workItems[0].name).toBe('Test Work Item');
@@ -70,12 +70,12 @@ describe('fetchWorkItems', () => {
   it('maps Bitbucket repository metadata from work items', async () => {
     const bitbucketConnection = {
       query: vi.fn().mockImplementation((query: string) => {
-        if (query.includes("WHERE DevopsProjectId = 'project-bitbucket'")) {
+        if (query.includes("WHERE DevopsProjectId = '001xx0000012346'")) {
           return {
             records: [{
               Id: 'WI-1001',
               Name: 'Bitbucket Item',
-              DevopsProjectId: 'project-bitbucket',
+              DevopsProjectId: '001xx0000012346',
               SourceCodeRepositoryBranch: {
                 Name: 'feature/WI-1001',
                 SourceCodeRepository: {
@@ -92,7 +92,7 @@ describe('fetchWorkItems', () => {
       request: vi.fn().mockResolvedValue({ owner: 'workspace-from-connect-api' })
     };
 
-    const workItems = await fetchWorkItems(bitbucketConnection as any, 'project-bitbucket');
+    const workItems = await fetchWorkItems(bitbucketConnection as any, '001xx0000012346');
     expect(workItems).toHaveLength(1);
     expect(workItems[0].SourceCodeRepository).toEqual({
       repoUrl: 'https://bitbucket.org/test-workspace/test-repo',
@@ -107,12 +107,12 @@ describe('fetchWorkItems', () => {
   it('normalizes bitbucketcloud provider to bitbucket repoType', async () => {
     const bitbucketCloudConnection = {
       query: vi.fn().mockImplementation((query: string) => {
-        if (query.includes("WHERE DevopsProjectId = 'project-bitbucket-cloud'")) {
+        if (query.includes("WHERE DevopsProjectId = '001xx0000012347'")) {
           return {
             records: [{
               Id: 'WI-1002',
               Name: 'Bitbucket Cloud Item',
-              DevopsProjectId: 'project-bitbucket-cloud',
+              DevopsProjectId: '001xx0000012347',
               SourceCodeRepositoryBranch: {
                 Name: 'feature/WI-1002',
                 SourceCodeRepository: {
@@ -129,7 +129,7 @@ describe('fetchWorkItems', () => {
       request: vi.fn().mockResolvedValue({ owner: 'cloud-workspace-from-connect-api' })
     };
 
-    const workItems = await fetchWorkItems(bitbucketCloudConnection as any, 'project-bitbucket-cloud');
+    const workItems = await fetchWorkItems(bitbucketCloudConnection as any, '001xx0000012347');
     expect(workItems).toHaveLength(1);
     expect(workItems[0].SourceCodeRepository).toEqual({
       repoUrl: 'https://bitbucket.org/cloud-workspace/cloud-repo',
@@ -144,12 +144,12 @@ describe('fetchWorkItems', () => {
   it('uses GitHub owner from connect vcs API for repo URL', async () => {
     const githubConnection = {
       query: vi.fn().mockImplementation((query: string) => {
-        if (query.includes("WHERE DevopsProjectId = 'project-github'")) {
+        if (query.includes("WHERE DevopsProjectId = '001xx0000012348'")) {
           return {
             records: [{
               Id: 'WI-2001',
               Name: 'GitHub Item',
-              DevopsProjectId: 'project-github',
+              DevopsProjectId: '001xx0000012348',
               SourceCodeRepositoryBranch: {
                 Name: 'feature/WI-2001',
                 SourceCodeRepository: {
@@ -166,7 +166,7 @@ describe('fetchWorkItems', () => {
       request: vi.fn().mockResolvedValue({ owner: 'owner-from-connect-api' })
     };
 
-    const workItems = await fetchWorkItems(githubConnection as any, 'project-github');
+    const workItems = await fetchWorkItems(githubConnection as any, '001xx0000012348');
     expect(workItems).toHaveLength(1);
     expect(workItems[0].SourceCodeRepository).toEqual({
       repoUrl: 'https://github.com/owner-from-connect-api/repo-one',

--- a/packages/mcp-provider-devops/test/getWorkItemsMP.test.ts
+++ b/packages/mcp-provider-devops/test/getWorkItemsMP.test.ts
@@ -23,29 +23,29 @@ function createMockConnection(workItemRecord: any, pipelineRecord: any, stagesRe
 
 describe('fetchWorkItemByNameMP', () => {
   it('should return a work item successfully', async () => {
-    const workItemRecord = { Id: 'WI-0001', Name: 'Test Work Item', sf_devops__Project__c: 'P-001' };
-    const pipelineRecord = { Id: 'PL-001', Name: 'Pipeline 1', sf_devops__Project__c: 'P-001' };
-    const stagesRecords = [{ Id: 'PS-001', Name: 'Stage 1', sf_devops__Next_Stage__c: null }];
+    const workItemRecord = { Id: 'a07xx0000000001', Name: 'Test Work Item', sf_devops__Project__c: 'a0Bxx00000002Cd' };
+    const pipelineRecord = { Id: 'a0Axx00000001Ab', Name: 'Pipeline 1', sf_devops__Project__c: 'a0Bxx00000002Cd' };
+    const stagesRecords = [{ Id: 'a08xx0000000001', Name: 'Stage 1', sf_devops__Next_Stage__c: null }];
     const mockConnection = createMockConnection(workItemRecord, pipelineRecord, stagesRecords);
 
     const workItem = await fetchWorkItemByNameMP(mockConnection, 'WI-0001');
-    expect(workItem.id).toBe('WI-0001');
+    expect(workItem.id).toBe('a07xx0000000001');
     expect(workItem.name).toBe('Test Work Item');
   });
 
   it('infers bitbucket repoType from managed package repository URL', async () => {
     const workItemRecord = {
-      Id: 'WI-0001',
+      Id: 'a07xx0000000002',
       Name: 'Test Work Item',
-      sf_devops__Project__c: 'P-001',
+      sf_devops__Project__c: 'a0Bxx00000002Cd',
       sf_devops__Branch__r: {
         sf_devops__Repository__r: {
           sf_devops__Url__c: 'https://bitbucket.org/acme/project-repo.git'
         }
       }
     };
-    const pipelineRecord = { Id: 'PL-001', Name: 'Pipeline 1', sf_devops__Project__c: 'P-001' };
-    const stagesRecords = [{ Id: 'PS-001', Name: 'Stage 1', sf_devops__Next_Stage__c: null }];
+    const pipelineRecord = { Id: 'a0Axx00000001Ab', Name: 'Pipeline 1', sf_devops__Project__c: 'a0Bxx00000002Cd' };
+    const stagesRecords = [{ Id: 'a08xx0000000001', Name: 'Stage 1', sf_devops__Next_Stage__c: null }];
     const mockConnection = createMockConnection(workItemRecord, pipelineRecord, stagesRecords);
 
     const workItem = await fetchWorkItemByNameMP(mockConnection as any, 'WI-0001');
@@ -53,9 +53,9 @@ describe('fetchWorkItemByNameMP', () => {
   });
 
   it('should return an error if work item is concluded', async () => {
-    const workItemRecord = { Id: 'WI-0001', Name: 'Test Work Item', sf_devops__Concluded__c: 'true', sf_devops__Project__c: 'P-001' };
-    const pipelineRecord = { Id: 'PL-001', Name: 'Pipeline 1', sf_devops__Project__c: 'P-001' };
-    const stagesRecords = [{ Id: 'PS-001', Name: 'Stage 1' }];
+    const workItemRecord = { Id: 'a07xx0000000003', Name: 'Test Work Item', sf_devops__Concluded__c: 'true', sf_devops__Project__c: 'a0Bxx00000002Cd' };
+    const pipelineRecord = { Id: 'a0Axx00000001Ab', Name: 'Pipeline 1', sf_devops__Project__c: 'a0Bxx00000002Cd' };
+    const stagesRecords = [{ Id: 'a08xx0000000001', Name: 'Stage 1' }];
     const mockConnection = createMockConnection(workItemRecord, pipelineRecord, stagesRecords);
 
     const result = await fetchWorkItemByNameMP(mockConnection, 'WI-0001');

--- a/packages/mcp-provider-devops/test/shared/soqlUtils.test.ts
+++ b/packages/mcp-provider-devops/test/shared/soqlUtils.test.ts
@@ -1,0 +1,134 @@
+import { expect } from 'chai';
+import {
+    isValidSalesforceId,
+    escapeSoqlString,
+    validateSalesforceId,
+    isValidWorkItemName,
+    validateWorkItemName
+} from '../../src/shared/soqlUtils.js';
+
+describe('soqlUtils', () => {
+    describe('isValidSalesforceId', () => {
+        it('should accept valid 15-character Salesforce IDs', () => {
+            expect(isValidSalesforceId('001xx000003DGb2')).to.be.true;
+            expect(isValidSalesforceId('a07EE00002aJTv0')).to.be.true;
+        });
+
+        it('should accept valid 18-character Salesforce IDs', () => {
+            expect(isValidSalesforceId('001xx000003DGb2AAG')).to.be.true;
+            expect(isValidSalesforceId('a07EE00002aJTv0YAG')).to.be.true;
+        });
+
+        it('should reject IDs with invalid length', () => {
+            expect(isValidSalesforceId('123')).to.be.false;
+            expect(isValidSalesforceId('001xx000003DGb2AAGEXTRA')).to.be.false;
+        });
+
+        it('should reject IDs with SQL injection attempts', () => {
+            expect(isValidSalesforceId("001' OR 1=1--")).to.be.false;
+            expect(isValidSalesforceId("'; DROP TABLE--")).to.be.false;
+        });
+
+        it('should reject non-string values', () => {
+            expect(isValidSalesforceId(null as any)).to.be.false;
+            expect(isValidSalesforceId(undefined as any)).to.be.false;
+            expect(isValidSalesforceId(123 as any)).to.be.false;
+        });
+    });
+
+    describe('escapeSoqlString', () => {
+        it('should escape single quotes', () => {
+            expect(escapeSoqlString("O'Brien")).to.equal("O\\'Brien");
+            expect(escapeSoqlString("It's working")).to.equal("It\\'s working");
+        });
+
+        it('should handle strings without quotes', () => {
+            expect(escapeSoqlString("normal text")).to.equal("normal text");
+        });
+
+        it('should handle empty strings', () => {
+            expect(escapeSoqlString("")).to.equal("");
+        });
+
+        it('should throw on non-string values', () => {
+            expect(() => escapeSoqlString(null as any)).to.throw();
+            expect(() => escapeSoqlString(123 as any)).to.throw();
+        });
+    });
+
+    describe('validateSalesforceId', () => {
+        it('should return trimmed valid IDs', () => {
+            expect(validateSalesforceId('001xx000003DGb2')).to.equal('001xx000003DGb2');
+            expect(validateSalesforceId(' a07EE00002aJTv0 ')).to.equal('a07EE00002aJTv0');
+        });
+
+        it('should throw on invalid IDs', () => {
+            expect(() => validateSalesforceId('invalid')).to.throw(/Invalid Salesforce ID/);
+            expect(() => validateSalesforceId("001' OR 1=1--")).to.throw(/Invalid Salesforce ID/);
+        });
+
+        it('should include field name in error message', () => {
+            try {
+                validateSalesforceId('invalid', 'projectId');
+                expect.fail('Should have thrown');
+            } catch (error: any) {
+                expect(error.message).to.include('projectId');
+            }
+        });
+    });
+
+    describe('isValidWorkItemName', () => {
+        it('should accept valid work item names', () => {
+            expect(isValidWorkItemName('WI-12345')).to.be.true;
+            expect(isValidWorkItemName('WI-0001')).to.be.true;
+            expect(isValidWorkItemName('WI-9999999')).to.be.true;
+        });
+
+        it('should reject invalid formats', () => {
+            expect(isValidWorkItemName('W-12345')).to.be.false;
+            expect(isValidWorkItemName('WI12345')).to.be.false;
+            expect(isValidWorkItemName('WI-')).to.be.false;
+            expect(isValidWorkItemName('WI-ABC')).to.be.false;
+        });
+
+        it('should reject SQL injection attempts', () => {
+            expect(isValidWorkItemName("WI-0001' OR Name != 'x")).to.be.false;
+            expect(isValidWorkItemName("'; DROP TABLE--")).to.be.false;
+        });
+
+        it('should reject non-string values', () => {
+            expect(isValidWorkItemName(null as any)).to.be.false;
+            expect(isValidWorkItemName(undefined as any)).to.be.false;
+        });
+    });
+
+    describe('validateWorkItemName', () => {
+        it('should return escaped valid work item names', () => {
+            expect(validateWorkItemName('WI-12345')).to.equal('WI-12345');
+            expect(validateWorkItemName(' WI-0001 ')).to.equal('WI-0001');
+        });
+
+        it('should throw on invalid work item names', () => {
+            expect(() => validateWorkItemName('invalid')).to.throw(/Invalid work item name format/);
+            expect(() => validateWorkItemName("WI-0001' OR 1=1--")).to.throw(/Invalid work item name format/);
+        });
+    });
+
+    describe('SQL injection prevention', () => {
+        it('should prevent common injection patterns', () => {
+            const injectionAttempts = [
+                "' OR '1'='1",
+                "'; DROP TABLE WorkItem--",
+                "' UNION SELECT * FROM User--",
+                "' OR 1=1--",
+                "admin'--",
+                "' OR 'x'='x"
+            ];
+
+            injectionAttempts.forEach(attempt => {
+                expect(isValidSalesforceId(attempt), `Should reject: ${attempt}`).to.be.false;
+                expect(isValidWorkItemName(attempt), `Should reject: ${attempt}`).to.be.false;
+            });
+        });
+    });
+});

--- a/packages/mcp-provider-devops/test/shared/soqlUtils.test.ts
+++ b/packages/mcp-provider-devops/test/shared/soqlUtils.test.ts
@@ -4,7 +4,8 @@ import {
     escapeSoqlString,
     validateSalesforceId,
     isValidWorkItemName,
-    validateWorkItemName
+    validateWorkItemName,
+    containsSqlInjectionPatterns
 } from '../../src/shared/soqlUtils.js';
 
 describe('soqlUtils', () => {
@@ -108,14 +109,54 @@ describe('soqlUtils', () => {
             expect(validateWorkItemName(' WI-0001 ')).to.equal('WI-0001');
         });
 
-        it('should throw on invalid work item names', () => {
-            expect(() => validateWorkItemName('invalid')).to.throw(/Invalid work item name format/);
-            expect(() => validateWorkItemName("WI-0001' OR 1=1--")).to.throw(/Invalid work item name format/);
+        it('should allow alphanumeric work item names for managed packages', () => {
+            expect(validateWorkItemName('Test Work Item')).to.equal('Test Work Item');
+            expect(validateWorkItemName('My_Work_Item-123')).to.equal('My_Work_Item-123');
+            expect(validateWorkItemName('Feature 2024')).to.equal('Feature 2024');
+        });
+
+        it('should escape single quotes in work item names', () => {
+            expect(validateWorkItemName("O'Brien Task")).to.equal("O\\'Brien Task");
+        });
+
+        it('should throw on SQL injection attempts', () => {
+            expect(() => validateWorkItemName("WI-0001' OR 1=1--")).to.throw(/SQL injection/);
+            expect(() => validateWorkItemName("Test'; DROP TABLE--")).to.throw(/SQL injection/);
+            expect(() => validateWorkItemName("WI-001 UNION SELECT")).to.throw(/SQL injection/);
+            expect(() => validateWorkItemName("Task OR Name != 'x'")).to.throw(/SQL injection/);
+        });
+
+        it('should throw on special characters that could be dangerous', () => {
+            expect(() => validateWorkItemName('Task<script>')).to.throw(/Invalid work item name format/);
+            expect(() => validateWorkItemName('Task;DROP;')).to.throw(/SQL injection/);
+        });
+    });
+
+    describe('containsSqlInjectionPatterns', () => {
+        it('should detect SQL injection patterns', () => {
+            expect(containsSqlInjectionPatterns("' OR '1'='1")).to.be.true;
+            expect(containsSqlInjectionPatterns("'; DROP TABLE--")).to.be.true;
+            expect(containsSqlInjectionPatterns("test UNION SELECT")).to.be.true;
+            expect(containsSqlInjectionPatterns("value--comment")).to.be.true;
+            expect(containsSqlInjectionPatterns("item; DELETE FROM")).to.be.true;
+        });
+
+        it('should allow safe strings', () => {
+            expect(containsSqlInjectionPatterns("WI-12345")).to.be.false;
+            expect(containsSqlInjectionPatterns("Test Work Item")).to.be.false;
+            expect(containsSqlInjectionPatterns("Feature_123")).to.be.false;
+        });
+
+        it('should handle single quotes that will be escaped', () => {
+            // Single quotes alone are not blocked since we escape them
+            expect(containsSqlInjectionPatterns("O'Brien")).to.be.false;
+            // But quotes with injection keywords should be blocked
+            expect(containsSqlInjectionPatterns("O'Brien' OR 1=1")).to.be.true;
         });
     });
 
     describe('SQL injection prevention', () => {
-        it('should prevent common injection patterns', () => {
+        it('should prevent common injection patterns in Salesforce IDs', () => {
             const injectionAttempts = [
                 "' OR '1'='1",
                 "'; DROP TABLE WorkItem--",
@@ -127,7 +168,20 @@ describe('soqlUtils', () => {
 
             injectionAttempts.forEach(attempt => {
                 expect(isValidSalesforceId(attempt), `Should reject: ${attempt}`).to.be.false;
-                expect(isValidWorkItemName(attempt), `Should reject: ${attempt}`).to.be.false;
+            });
+        });
+
+        it('should prevent injection patterns in work item names via validateWorkItemName', () => {
+            const injectionAttempts = [
+                "' OR '1'='1",
+                "'; DROP TABLE WorkItem--",
+                "' UNION SELECT * FROM User--",
+                "' OR 1=1--",
+                "test' OR 'x'='x"
+            ];
+
+            injectionAttempts.forEach(attempt => {
+                expect(() => validateWorkItemName(attempt), `Should reject: ${attempt}`).to.throw();
             });
         });
     });


### PR DESCRIPTION
Fixes @W-22550530@

This commit addresses SOQL injection vulnerabilities in the MCP DevOps provider by implementing strict input validation for all user-provided values in SOQL queries.

Changes:
- Created soqlUtils.ts with validation functions for Salesforce IDs and work item names
- Added isValidSalesforceId() to validate 15/18 character ID format
- Added validateWorkItemName() to validate WI-XXXXXXX format
- Added escapeSoqlString() for proper quote escaping
- Applied validation to all SOQL queries in:
  * getWorkItems.ts (projectId, workItemName)
  * getWorkItemsMP.ts (workItemName, workItemId)
  * getPipelineMP.ts (projectId)
  * getPipelineStagesMP.ts (pipelineId)
- Added comprehensive unit tests for all validation functions

Security improvements:
- Prevents injection via malformed IDs like "001' OR 1=1--"
- Validates work item name format before query construction
- Rejects all non-alphanumeric characters in IDs
- Blocks common SQL injection patterns

### What does this PR do?

### What issues does this PR fix or reference?
