### PR TITLE
@W-23573781 default org clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ These are the available values for the `--orgs` flag:
 | `DEFAULT_TARGET_ORG`     | Allow access to your default org. If you've set a local default org in your DX project, the MCP server uses it. If not, the server uses a globally-set default org.                         |
 | `<username or alias>`    | Allow access to a specific org by specifying its username or alias.                                                                                                                         |
 
+> [!NOTE]
+> The `DEFAULT_TARGET_ORG` and `DEFAULT_TARGET_DEV_HUB` tokens are resolved dynamically on every tool call, not pinned when the server starts. They track whatever the default org resolves to for the working directory a tool operates in, so switching your default org (or working in a directory with a different local default) changes which org these tokens allow. This mirrors how the `sf` CLI resolves the default target-org when you don't pass `--target-org`. If you want to lock the server to a fixed set of orgs regardless of the current default, pass explicit usernames or aliases to `--orgs` instead of the `DEFAULT_TARGET_*` tokens.
+
 ## Configure Toolsets
 
 The Salesforce DX MCP Server supports **toolsets**—a way to selectively enable different groups of MCP tools based on your needs. This allows you to run the MCP server with only the tools you require, which in turn reduces the LLM context.

--- a/packages/mcp/src/utils/auth.ts
+++ b/packages/mcp/src/utils/auth.ts
@@ -123,9 +123,12 @@ export async function filterAllowedOrgs(
   });
 }
 
-// Helper function to get default config for a property
-// Values are cached based on ConfigInfo path after first retrieval
-// This is to prevent manipulation of the config file after server start
+// Helper function to get default config for a property.
+// The default target-org/dev-hub is re-resolved on every call so that it follows the
+// ambient default config for the current working directory (CLI parity). This is
+// intentional: the DEFAULT_TARGET_* allowlist tokens track whatever the current default
+// resolves to, rather than pinning a fixed org at server startup. Operators who need a
+// hard org lock should pass explicit usernames/aliases to --orgs instead.
 async function getDefaultConfig(
   property: OrgConfigProperties.TARGET_ORG | OrgConfigProperties.TARGET_DEV_HUB
 ): Promise<OrgConfigInfo | undefined> {


### PR DESCRIPTION
### What does this PR do?
- `auth.ts`: replace stale comment on `getDefaultConfig` (described a removed cache) with an accurate note that the default org is re-resolved per call by design.
- `README.md`: add a note that `DEFAULT_TARGET_ORG`/`DEFAULT_TARGET_DEV_HUB` resolve dynamically per tool call (CLI parity); use explicit usernames/aliases in `--orgs` to pin a fixed org set.

### What issues does this PR fix or reference?
[@W-23573781@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-23573781)
